### PR TITLE
Hide external partner controller for future use

### DIFF
--- a/src/api/src/application/Yoma.Core.Api/Attributes/ApiKeyAttribute.cs
+++ b/src/api/src/application/Yoma.Core.Api/Attributes/ApiKeyAttribute.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using Yoma.Core.Api.Common;
-using Yoma.Core.Domain.Entity.Interfaces;
 
 namespace Yoma.Core.Api.Attributes
 {
@@ -10,14 +9,10 @@ namespace Yoma.Core.Api.Attributes
     public class ApiKeyAttribute : Attribute, IAsyncActionFilter
     {
         #region Class Variables
-        private readonly IOrganizationService _organizationService;
         #endregion
 
         #region Constructor
-        public ApiKeyAttribute(IOrganizationService organizationService)
-        {
-            _organizationService = organizationService;
-        }
+        public ApiKeyAttribute() { }
         #endregion
 
         #region Public Members
@@ -33,19 +28,9 @@ namespace Yoma.Core.Api.Attributes
                 return;
             }
 
-            var organization = _organizationService.GetByApiKeyOrNull(extractedApiKey.ToString());
-            if (organization == null)
-            {
-                context.Result = new ContentResult()
-                {
-                    StatusCode = (int)HttpStatusCode.Unauthorized,
-                    Content = HttpStatusCode.Unauthorized.ToString()
-                };
-                return;
-            }
-
-            //store the authenticated organization id in HttpContext.Items for subsequent use (HttpContext.Items.TryGetValue(Constants.HttpContextItemsKey_Authenticated_OrganizationId, out var organizationIdObj) && organizationIdObj is Guid organizationId)
-            context.HttpContext.Items[Constants.HttpContextItemsKey_Authenticated_OrganizationId] = organization.Id;
+            //validate key against configuration / storage
+            //StatusCode = (int)HttpStatusCode.Unauthorized,
+            //Content = HttpStatusCode.Unauthorized.ToString()
 
             await next();
         }

--- a/src/api/src/application/Yoma.Core.Api/Controllers/ExternalPartnerController.cs
+++ b/src/api/src/application/Yoma.Core.Api/Controllers/ExternalPartnerController.cs
@@ -5,17 +5,35 @@ using System.Net;
 
 namespace Yoma.Core.Api.Controllers
 {
+    [ApiExplorerSettings(IgnoreApi = true)]
     [Route("api/v3/externalpartner")]
     [ApiController]
     [Authorize(Policy = Common.Constants.Authorization_Policy_External_Partner)]
-    [SwaggerTag("By default, obtain an external partner bearer token via the Client Credentials flow")]
+    [SwaggerTag("(by default, requires an external partner bearer token obtained via the Client Credentials flow)")]
     public class ExternalPartnerController : Controller
     {
-        [HttpGet()]
+        #region Class Variables
+        private readonly ILogger<OpportunityController> _logger;
+        #endregion
+
+        #region Constructor
+        public ExternalPartnerController(ILogger<OpportunityController> logger)
+        {
+            _logger = logger;
+        }
+        #endregion
+
+        #region Public Members
+        #region Authenticated Actions
+        [SwaggerOperation(Summary = "Test authentication and return 'OK'")]
+        [HttpGet("test/action")]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
         public IActionResult TestAction()
         {
             return StatusCode((int)HttpStatusCode.OK);
         }
+        #endregion Authenticated Actions
+        #endregion Public Members
     }
 }
 

--- a/src/api/src/domain/Yoma.Core.Domain/Entity/Interfaces/IOrganizationService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Entity/Interfaces/IOrganizationService.cs
@@ -13,10 +13,6 @@ namespace Yoma.Core.Domain.Entity.Interfaces
 
         Organization? GetByNameOrNull(string name, bool includeChildItems, bool includeComputed);
 
-        Organization GetByApiKey(string apiKey);
-
-        Organization GetByApiKeyOrNull(string apiKey);
-
         List<Organization> Contains(string value, bool includeComputed);
 
         OrganizationSearchResults Search(OrganizationSearchFilter filter, bool ensureOrganizationAuthorization);

--- a/src/api/src/domain/Yoma.Core.Domain/Entity/Services/OrganizationService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Entity/Services/OrganizationService.cs
@@ -154,16 +154,6 @@ namespace Yoma.Core.Domain.Entity.Services
             return result;
         }
 
-        public Organization GetByApiKey(string apiKey)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Organization GetByApiKeyOrNull(string apiKey)
-        {
-            throw new NotImplementedException();
-        }
-
         public List<Organization> Contains(string value, bool includeComputed)
         {
             if (string.IsNullOrWhiteSpace(value))

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Enumerations.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Enumerations.cs
@@ -15,7 +15,7 @@ namespace Yoma.Core.Domain.Opportunity
         /// </summary>
         Manual,
         /// <summary>
-        /// Verification by the provider directly / automatically via SSI integration
+        /// Verification by the provider directly / automatically via integration
         /// </summary>
         Automatic
     }

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
@@ -523,6 +523,9 @@ namespace Yoma.Core.Domain.Opportunity.Services
 
             var organization = _organizationService.GetById(request.OrganizationId, false, true, false);
 
+            if (organization.Status != OrganizationStatus.Active)
+                throw new ValidationException($"An opportunity cannot be created as the associated organization '{organization.Name}' is not currently active (pending approval)");
+
             var result = new Models.Opportunity
             {
                 Title = request.Title,
@@ -608,6 +611,9 @@ namespace Yoma.Core.Domain.Opportunity.Services
             var user = _userService.GetByEmail(HttpContextAccessorHelper.GetUsername(_httpContextAccessor, !ensureOrganizationAuthorization), false, false);
 
             var organization = _organizationService.GetById(request.OrganizationId, false, true, false);
+
+            if (organization.Status != OrganizationStatus.Active)
+                throw new ValidationException($"The opportunity cannot be updated as the associated organization '{organization.Name}' is not currently active (pending approval)");
 
             //status remains unchanged (status updated via UpdateStatus)
             result.Title = request.Title;


### PR DESCRIPTION
Remove GetByApiKey method from organization service Require active associated organization for creating and updating opportunities