### PR TITLE
Multi-arch Docker

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -164,7 +164,7 @@ jobs:
       - uses: docker/build-push-action@v5
         if: steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
         with:
-          platforms: linux/amd64 # linux/arm64/v8 is a little too slow right now
+          platforms: linux/amd64,linux/arm64/v8
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           push: true


### PR DESCRIPTION
* Github Runners for Public Repos are now quad-core
* https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/
* Maybe it's fast enough now for multi-arch docker images