### PR TITLE
Multi-arch docker

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,6 +141,8 @@ jobs:
           filters: |-
             changes:
               - '${{ matrix.context }}/**'
+      - uses: docker/setup-qemu-action@v3
+        if: steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
       - uses: docker/setup-buildx-action@v3
         if: steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
       - uses: docker/login-action@v3
@@ -164,7 +166,7 @@ jobs:
       - uses: docker/build-push-action@v5
         if: steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
         with:
-          platforms: linux/amd64 # linux/arm64/v8 is a little too slow right now
+          platforms: linux/amd64,linux/arm64/v8
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           push: true

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3"
+
 name: yoma-v3
 services:
   postgres:

--- a/src/web/docker-compose.yml
+++ b/src/web/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3"
+
 name: yoma-v3
 services:
   yoma-web:


### PR DESCRIPTION
* Github Runners for Public Repos are now quad-core
* https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/
* Maybe it's fast enough now for multi-arch docker images