### PR TITLE
Set End-Of-Line to `lf`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto eol=lf
+
 secrets.yaml diff=sopsdiffer


### PR DESCRIPTION
Force all text files to `\n` on end of line.

Should, hopefully, mean no more worrying about DOS `\r\n` and *nix `\n` clashes anymore.