### PR TITLE
[YOMA-16] Fix missing `Should deploy` check for `release`

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -367,7 +367,8 @@ jobs:
       - name: Should deploy?
         id: should-run
         run: |-
-          if [ "${{ steps.filter.outputs.api }}" = "true" ] || \
+          if [ "${{ github.event_name }}" = "release" ] \
+              [ "${{ steps.filter.outputs.api }}" = "true" ] || \
               [ "${{ steps.filter.outputs.web }}" = "true" ] || \
               [ "${{ steps.filter.outputs.keycloak }}" = "true" ] || \
               [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
Because, obviously, we want to deploy things to prod when we do a release