### PR TITLE
Set up basic and detailed health checks at /api/v3/health/ready and /api/v3/health/live

### DIFF
--- a/helm/yoma-api/templates/deployment.yaml
+++ b/helm/yoma-api/templates/deployment.yaml
@@ -62,13 +62,13 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /index.html
+              path: /api/v3/health/live
               port: {{ .Values.service.portName | default "http"  }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /index.html
+              path: /api/v3/health/ready
               port: {{ .Values.service.portName | default "http"  }}
           {{- end }}
           resources:

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Startup.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Startup.cs
@@ -54,8 +54,8 @@ namespace Yoma.Core.Infrastructure.Database
               })
         //disable warning related to not using AsSplitQuery() as per MS SQL implementation
         //.UseLazyLoadingProxies(): without arguments is used to enable lazy loading. Simply not calling UseLazyLoadingProxies() ensure lazy loading is not enabled
-        .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.MultipleCollectionIncludeWarning)); 
-                                                                                                                   
+        .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.MultipleCollectionIncludeWarning));
+
       }, ServiceLifetime.Scoped, ServiceLifetime.Scoped);
 
       services.AddHealthChecks().AddNpgSql(

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Startup.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Startup.cs
@@ -52,9 +52,16 @@ namespace Yoma.Core.Infrastructure.Database
                           maxRetryDelay: TimeSpan.FromSeconds(appSettings.DatabaseRetryPolicy.MaxRetryDelayInSeconds),
                           errorCodesToAdd: null);
               })
-              .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.MultipleCollectionIncludeWarning)); //didable warning related to not using AsSplitQuery() as per MS SQL implementation
-                                                                                                                   //.UseLazyLoadingProxies(): without arguments is used to enable lazy loading. Simply not calling UseLazyLoadingProxies() ensure lazy loading is not enabled
+        //disable warning related to not using AsSplitQuery() as per MS SQL implementation
+        //.UseLazyLoadingProxies(): without arguments is used to enable lazy loading. Simply not calling UseLazyLoadingProxies() ensure lazy loading is not enabled
+        .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.MultipleCollectionIncludeWarning)); 
+                                                                                                                   
       }, ServiceLifetime.Scoped, ServiceLifetime.Scoped);
+
+      services.AddHealthChecks().AddNpgSql(
+        connectionString: configuration.Configuration_ConnectionString(),
+        name: "Database Connectivity Check",
+        tags: ["live"]);
 
       //<PackageReference Include="EntityFrameworkProfiler.Appender" Version="6.0.6040" />
       //if (environment == Domain.Core.Environment.Local)

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Yoma.Core.Infrastructure.Database.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Yoma.Core.Infrastructure.Database.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Enable anonymous access to these endpoints to allow health monitoring by external systems without authentication Utilize default ASP.NET Core Health Checks behavior to return HTTP 200 for Healthy and HTTP 503 for Unhealthy or Degraded states, facilitating straightforward integration with load balancers and monitoring tools