### PR TITLE
[YOMA-15] Migrate Yoma Web to `yoma.world`

### DIFF
--- a/helm/keycloak/conf/dev/values.yaml
+++ b/helm/keycloak/conf/dev/values.yaml
@@ -5,7 +5,10 @@ ingress:
       - host: dev.yoma.world
         paths:
           - path: /auth
-
+  internal-admin:
+    enabled: true
+    rules:
+      - host: auth.dev.yoma.world
   external:
     enabled: false
     rules:

--- a/helm/keycloak/conf/dev/values.yaml
+++ b/helm/keycloak/conf/dev/values.yaml
@@ -36,9 +36,6 @@ keycloak:
       cpu: 2500m
       memory: 512Mi
 
-  http:
-    relativePath: /auth
-
   themes:
     enabled: true
     ref: master

--- a/helm/keycloak/conf/dev/values.yaml
+++ b/helm/keycloak/conf/dev/values.yaml
@@ -1,10 +1,6 @@
 ingress:
   internal:
     enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |-
-        more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://dev.yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
       - host: dev.yoma.world
         paths:
@@ -12,10 +8,6 @@ ingress:
 
   external:
     enabled: false
-    annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |-
-        more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://dev.yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
       - host: dev.yoma.world
         paths:

--- a/helm/keycloak/conf/local/values.yaml
+++ b/helm/keycloak/conf/local/values.yaml
@@ -34,9 +34,6 @@ keycloak:
       cpu: 2500m
       memory: 512Mi
 
-  http:
-    relativePath: /auth
-
   themes:
     enabled: false
     ref: develop

--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -5,6 +5,10 @@ ingress:
       - host: yoma.world
         paths:
           - path: /auth
+  internal-admin:
+    enabled: true
+    rules:
+      - host: auth.yoma.world
   external:
     enabled: true
     rules:

--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -1,20 +1,12 @@
 ingress:
   internal:
     enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |-
-        more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
       - host: yoma.world
         paths:
           - path: /auth
   external:
     enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |-
-        more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
       - host: yoma.world
         paths:

--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -11,7 +11,13 @@ ingress:
       - host: auth.yoma.world
   external:
     enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |-
+        if ($host = 'auth.yoma.world') {
+          rewrite ^ https://yoma.world/auth$request_uri permanent;
+        }
     rules:
+      - host: auth.yoma.world
       - host: yoma.world
         paths:
           - path: /auth/realms/yoma

--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -4,21 +4,23 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://app.yoma.world; frame-src 'self'; object-src 'none';" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' https://yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
-      - host: auth.yoma.world
+      - host: yoma.world
+        paths:
+          - path: /auth
   external:
     enabled: true
     annotations:
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://app.yoma.world; frame-src 'self'; object-src 'none';" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' https://yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
-      - host: auth.yoma.world
+      - host: yoma.world
         paths:
-          - path: /realms/yoma
-          - path: /resources
-          - path: /js
+          - path: /auth/realms/yoma
+          - path: /auth/resources
+          - path: /auth/js
 
 postInstallHook:
   enabled: false
@@ -84,13 +86,13 @@ keycloak:
 config-cli:
   enabled: true
   env:
-    KEYCLOAK_URL: https://auth.yoma.world
+    KEYCLOAK_URL: https://yoma.world/auth
     IMPORT_FILES_LOCATIONS: "/init/*.yaml"
     # KEYCLOAK_USER: xxx
     # REALM_YOMA_ADMIN_CLI_SECRET: xxx
     # SMTP_PASSWORD: SG.xxx
     CLIENT_YOMA_API_URL: https://api.yoma.world
-    CLIENT_YOMA_WEB_URL: https://app.yoma.world
+    CLIENT_YOMA_WEB_URL: https://yoma.world
     CLIENT_ATINGI_URL: https://online.atingi.org
     CLIENT_ATINGI_URL_REDIRECT: https://keycloak.atingi.org/realms/master/broker/yoma-prod/endpoint
     CLIENT_ATINGI_URL_POST_LOGOUT_REDIRECT: https://keycloak.atingi.org/realms/master/broker/yoma-prod/endpoint

--- a/helm/keycloak/conf/stage/values.yaml
+++ b/helm/keycloak/conf/stage/values.yaml
@@ -1,20 +1,12 @@
 ingress:
   internal:
     enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |-
-        more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://stage.yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
       - host: stage.yoma.world
         paths:
           - path: /auth
   external:
     enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |-
-        more_clear_headers "Content-Security-Policy";
-        add_header Content-Security-Policy "frame-ancestors 'self' https://stage.yoma.world; frame-src 'self'; object-src 'none';" always;
     rules:
       - host: stage.yoma.world
         paths:

--- a/helm/keycloak/conf/stage/values.yaml
+++ b/helm/keycloak/conf/stage/values.yaml
@@ -5,6 +5,10 @@ ingress:
       - host: stage.yoma.world
         paths:
           - path: /auth
+  internal-admin:
+    enabled: true
+    rules:
+      - host: auth.stage.yoma.world
   external:
     enabled: true
     rules:

--- a/helm/keycloak/conf/stage/values.yaml
+++ b/helm/keycloak/conf/stage/values.yaml
@@ -35,9 +35,6 @@ keycloak:
       cpu: 2500m
       memory: 512Mi
 
-  http:
-    relativePath: /auth
-
   themes:
     enabled: true
     ref: master

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -10,7 +10,14 @@ ingress:
       - host: example.com
         paths:
           - path: /auth
-
+  internal-admin:
+    enabled: false
+    annotations:
+      nginx.ingress.kubernetes.io/app-root: /auth
+      nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    className: nginx-internal
+    rules:
+      - host: auth.example.com
   external:
     enabled: false
     annotations:

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -7,7 +7,9 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     className: nginx-internal
     rules:
-      - host: keycloak.example.com
+      - host: example.com
+        paths:
+          - path: /auth
 
   external:
     enabled: false
@@ -15,11 +17,11 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     className: nginx-external
     rules:
-      - host: keycloak.example.com
+      - host: example.com
         paths:
-          # - path: /realms/example
-          - path: /resources
-          - path: /js
+          # - path: /auth/realms/example
+          - path: /auth/resources
+          - path: /auth/js
 
 postInstallHook:
   enabled: false
@@ -42,7 +44,7 @@ postInstallHook:
 
   env:
     - name: KC_BASE_URL
-      value: http://keycloak-http:80
+      value: http://keycloak-http:80/auth
     - name: KC_REALM
       valueFrom:
         secretKeyRef:
@@ -355,8 +357,7 @@ keycloak:
     enabled: true
 
   http:
-    # TODO: migrate to /auth
-    relativePath: /
+    relativePath: /auth
 
   autoscaling:
     # If `true`, an autoscaling/v2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.23 or above)
@@ -394,6 +395,7 @@ config-cli:
     tag: 5.8.0-22.0.0
 
   env:
+    KEYCLOAK_URL: https://keycloak.example.com/auth
     KEYCLOAK_AVAILABILITYCHECK_ENABLED: "true"
     KEYCLOAK_AVAILABILITYCHECK_TIMEOUT: "120s"
     IMPORT_VALIDATE: "true"

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -325,7 +325,7 @@ keycloak:
     admission.datadoghq.com/enabled: "false" # disabled by default (for now)
   podAnnotations:
     # gcr.io/datadoghq/dd-lib-java-init
-    admission.datadoghq.com/java-lib.version: v1.31.2
+    admission.datadoghq.com/java-lib.version: v1.33.0
     ad.datadoghq.com/keycloak.logs: '[{ "service": "keycloak", "source": "jboss_wildfly" }]'
 
   resources:

--- a/helm/yoma-api/conf/prod/secrets.yaml
+++ b/helm/yoma-api/conf/prod/secrets.yaml
@@ -3,9 +3,9 @@ appSettings:
         MinimumLevel:
             Default: ENC[AES256_GCM,data:pLt1KFz/aQocNZg=,iv:v52N+fwG8rAxhHx6nFYD0qagND7Hu53MfGcFHL/I64g=,tag:83wL8hj5/YyOHGhrDPuHDw==,type:str]
     AppSettings:
-        AppBaseURL: ENC[AES256_GCM,data:xftWvThOt/XT5O5TlvlxNn8YcuM24g==,iv:9EybiYUwdZb4B1oLcwxLR1Eqtm+AwzVGyBKXc0Jy0mg=,tag:Y46euxmFesYIiFpj/aSFjg==,type:str]
+        AppBaseURL: ENC[AES256_GCM,data:ncjAApJwzp5/znKGmEU1Nr4M,iv:49gjsEwd0iaMTlnNaV+JnZ0eApGqtndrv9dEvDZ4W/s=,tag:H4talDKhZ5gttbzqycHqDA==,type:str]
         AllowedHosts: ENC[AES256_GCM,data:UA==,iv:b2jTfAVIg5m5UXsDMxO7Vb0aaOXVzUfrjKW3jWW9sQI=,tag:mdAAfC6OWEp5ETVb/FDGXA==,type:str]
-        AllowedOrigins: ENC[AES256_GCM,data:nc4bnLO45HtVHjs8S/MxMJH8jN1meN61gp8vEZgONHkkfe9LQD/8cz+lMpnYIwv/PN4PGXjioUOy4AhHEkhAY8vN,iv:Cj1xKjdcsfR/ueF65IWYeTj8rFPmuq9eQUsUhxucusg=,tag:jnkySr9+7JPKlnDk1Vv67Q==,type:str]
+        AllowedOrigins: ENC[AES256_GCM,data:Xg38ulLAyW3EFktP5H/IgidpskpmfwehiOD+Bp4XJORI8ecTNwu9wQ03i5Id+babvxE2JyezkAGi13aWHlY=,iv:ReL2u8qZEYgG15I9FEle3Bpcv97YL5K4IHsFePzjKXU=,tag:1XvzhAgvax6d1aeAwawvnA==,type:str]
         SSIIssuerNameYomaOrganization: ENC[AES256_GCM,data:1UBhaKVM3/BzQMC7dZkEPR2IrEaApCGxtHjjM2FyAg==,iv:hCas3b8m69wkSbV88r8UFc4Te3m2yzPOxL7rPlmshPo=,tag:++aG0GuZTB9kg2ZsVEB3HQ==,type:str]
         SSISchemaFullNameYoID: ENC[AES256_GCM,data:Fw+km5h8tCFDXPXW,iv:j4jLOcvrkidYN/GwkiT7aermN+tWTW945mdHNOoigx4=,tag:oi14XSI4P8cjJYjxxu22sQ==,type:str]
         TestDataSeedingEnvironments: ENC[AES256_GCM,data:SFs+lLIw/lLhZO+bivrvmzse,iv:npnOtJQrfKnOkNmonfKQ/Ejrblv+ttreUrF8hk298pE=,tag:CDzqfx4+h7H6iR9GZkJKgQ==,type:str]
@@ -36,7 +36,7 @@ appSettings:
             Password: ENC[AES256_GCM,data:zhuMzidzJMgT97pknm3AxH03SqjgxK2711GsjqERMdg=,iv:n+UFMSirwS8lnOKluTzrhG1abkDlyCRQVdTjbd7Qxkw=,tag:cwjIef/kkuuN5ooDIYDNkw==,type:str]
     Keycloak:
         realm: ENC[AES256_GCM,data:+o5X0Q==,iv:7KIbgq03FjkGoQpr7pgD8TTrYFN0NPmXR7j9fsureNI=,tag:OaKK54Lk55hJFAk0c8msRQ==,type:str]
-        auth-server-url: ENC[AES256_GCM,data:Cu4w4OCTpz8jaex6EgDZC3kku0/L+Js=,iv:pt6SGbj1AiEoRc0DJIwITa8/9rx4IxzbitT0jqjp3cE=,tag:z01UAB9jrZJVrJOjNhGJIg==,type:str]
+        auth-server-url: ENC[AES256_GCM,data:tgtUTClnu8PvKiwJ0wE/RsRF5lzYa0w=,iv:pRRynm+qQ16dHrK0kgINXx10ycsBsNjW3ihex7mSBeg=,tag:971hcl2EyWBqW3pWn2B1cw==,type:str]
         ssl-required: ENC[AES256_GCM,data:Ec6/SA==,iv:rVCUV3FOqrdpWAKhmrquHfqcM9KebGN1qiFf4j8XJ0Y=,tag:TjHep/ZXJHGH1KRASm6Ljg==,type:str]
         resource: ENC[AES256_GCM,data:yzlpqEjgjN0=,iv:igYrFzj//st4drPnfcqjIWNhKy1R2duh8Av7Wr6so/4=,tag:u3MkXTrJo1ZPJkum/Fq1qA==,type:str]
         verify-token-audience: ENC[AES256_GCM,data:qbdDsA==,iv:ZcKzcO7zFsjW/XH66zGE2NhETWKPE2d3gxsfSgmoEF8=,tag:cgM6RbWT0qu+XXUMDczqiQ==,type:bool]
@@ -101,8 +101,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-11T09:28:12Z"
-    mac: ENC[AES256_GCM,data:Nic94fKJUUsyFTIn5+9wnouHRoaG0YP55QOzaV22wpMZwiX3OxjCggsvKQo0TIaygbV/PrdcEFNViAe8O6h/e0O+2BcuX8f9IBb834pQzVBQsw5n2USmhg89z5EPM5No2L5O7UuthSD23t0dwazytKcu+RArH1//xl3RuMp1afU=,iv:NqIkcPyEcM/N/jkhs4zIqYUSICw5b37Cz0kxaQgBrSs=,tag:AwO+Ex03DKzkYeHijEzS1w==,type:str]
+    lastmodified: "2024-04-18T12:58:31Z"
+    mac: ENC[AES256_GCM,data:1HUjrG7FAwLJR06s8Oq6Htx2r1iaj+OsEu3i/svzNnHgK9SSfpfTgAMx3CgvAmWkHHQ2rB7h+MeLmaprtgjyJU4Mp1GmLDdhcUcH7q6QSHy7AqBQnk7pbiQ/9BzgF01IrLjCvjAL+OryJRoipJGPbw8zC0lh4qOM/Xbe/VNOIog=,iv:8x4NemNjMwGu+5ZsmOjglKr2i3kcN3dx3sDSf7Yc5m0=,tag:tIVTpACy6fxai/lsTCyexA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/helm/yoma-api/conf/prod/values.yaml
+++ b/helm/yoma-api/conf/prod/values.yaml
@@ -12,7 +12,7 @@ ingress:
     className: nginx-internal
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
-      nginx.ingress.kubernetes.io/cors-allow-origin: "https://app.yoma.world"
+      nginx.ingress.kubernetes.io/cors-allow-origin: "https://yoma.world"
     rules:
       - host: api.yoma.world
   external:
@@ -20,7 +20,7 @@ ingress:
     className: nginx-external
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
-      nginx.ingress.kubernetes.io/cors-allow-origin: "https://app.yoma.world"
+      nginx.ingress.kubernetes.io/cors-allow-origin: "https://yoma.world"
       nginx.ingress.kubernetes.io/server-snippet: |
         location /hangfire {
           deny all;

--- a/helm/yoma-web/conf/prod/secrets.yaml
+++ b/helm/yoma-web/conf/prod/secrets.yaml
@@ -2,9 +2,9 @@ envSecret:
     NEXTAUTH_SECRET: ENC[AES256_GCM,data:MmcE7brrm2Ug2OqVb+YxnnyRotBAPQw7WJAX/7p1Xjg=,iv:7M+sMcZ1ft3aUoK3cK4QNl8mfPWhgQxyWzZ28bj6fL4=,tag:tuQmadxe+44sTlEYyu5ksg==,type:str]
     KEYCLOAK_CLIENT_ID: ENC[AES256_GCM,data:M7+DUh94un4=,iv:r0H9Kef5fyuJLHTGD9LZZaw/0g8EwQLJHwL7dqnqHiU=,tag:TTTrS5zA3f/AP/nIqVq0zQ==,type:str]
     KEYCLOAK_CLIENT_SECRET: ENC[AES256_GCM,data:Wd77l9bSlmzKp6PDV4mpH+VrFKvcnAuQYWNlBLYNqzXU8yKlgK6NC9zfk8Br+XuLAfGkimUYQaepYJx/0ZnA6g==,iv:m9X6VQKvYdfeH6Ta3adRAMylYdBoAjPAbNUsd/6cziU=,tag:pYa0EDRKUyY2tslccqS1Ww==,type:str]
-    NEXTAUTH_URL: ENC[AES256_GCM,data:sF/lGL+dwCpzgljcoImu3zZPKj09Iw==,iv:Y1reaaVf4LaYzaDCg2NNvO0fsKugOCP2w/MbAbcRfkk=,tag:1NfOJIE+Dzp7Rwvd9N27Ig==,type:str]
+    NEXTAUTH_URL: ENC[AES256_GCM,data:Q3I/u1K3orLfEFqtaPAw4O41,iv:Gg++gpg/o2eCHL+/fnPceXr16N8guHKjylXsOIxql8Y=,tag:e9QUsM6o6P/3YD99ju0zXA==,type:str]
     API_BASE_URL: ENC[AES256_GCM,data:pL3RxaZ6Z2VxtIld/xJJUU7yKwt5pVtftW3h,iv:nIvKD2F+JVTyfbhLysqciNvn/gJ5XmGHPncnLnA3kDQ=,tag:OrEh8A0c8RPenyqhnSqeUA==,type:str]
-    KEYCLOAK_ISSUER: ENC[AES256_GCM,data:5Izgw0A6pEzqTzI3PGQgtYLCuVY5GkYHyVMG8UGR+gd9Iyo=,iv:Krp7wjQuX2QTqk7IfZSrKcD0+1cl5Ut/oeIWVWrh22c=,tag:MOpUe6JlE5tpVsPL6C3FQg==,type:str]
+    KEYCLOAK_ISSUER: ENC[AES256_GCM,data:yAB82HU4eIb0Y7vM3pYxg1oH4SYg/5Rq4EazbkyA42ys38k=,iv:XFRb3ZAeVNKpOPlBnB3N/b+TjZw269Gv1vb5UKoV9Jk=,tag:RuIwNgUwxNj1z2ZaCrJgEA==,type:str]
     NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ENC[AES256_GCM,data:qlIgT1/4//PkVhifm9g1bAWliBcjB6XZmN6VH4GWmvZG+3YPdqxr,iv:I+4Df6apJYnBnOQ+RY4BaPm2pDPLY3mJTNnJmMCVSA4=,tag:a3pR+GYHcGEpwRoEa0IETQ==,type:str]
     NEXT_PUBLIC_GA_MEASUREMENT_ID: ENC[AES256_GCM,data:WrvDfeU3DHbs3Xlh,iv:wFZVg6Lr0xcZpl+8qMLOrhe45s13rgwwyTz031FKUZU=,tag:O7PUiVvj5bLTnVbQdca5fw==,type:str]
 sops:
@@ -21,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-17T13:02:40Z"
-    mac: ENC[AES256_GCM,data:mElyjEyp4d4yvEPTP6G3ey08EfM+UEBYIYODrRLuaTi7J7squVccKHbcHolLWHWop2pJIEb8Yh3UZJaSERND6u+yTtx0iwFnq88KtdGMcYZXgNOQaUFh2RuFnwL9+xh2lG88DBGr4hF0vxBhv5Mi1k79w7tEEfaQEx3oMg+3WnE=,iv:i61mNb0KxghGqRo5BN9PG7IMIiCtuULXJ2Xd/iGuyQg=,tag:EVkx5ZoiH1SNC1Q5zxufJA==,type:str]
+    lastmodified: "2024-04-18T12:57:55Z"
+    mac: ENC[AES256_GCM,data:t0wC3V5R38dNNjl/XW3bTUCJ+tt9hAHldHR+mh0e52wzcqLSGzvk9qLjfYK74kNE8/koD/umIh6bCeCBBwc78/FkSLCUJpa5JVqohujmhyccoVIzveufQIsQKfsGW2CLHEQSrIlLgBRUplIJl6oXAI6LSwQRMfpvvLnXeBYknvs=,iv:JUh+AiGTAhPG9Mtdx/l/xeziAJPAlWO6nqGQ7gLnVk8=,tag:XsHWaDaux9kdaoVrq4pq4Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: ghcr.io/didx-xyz/yoma-web
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "master"
+  tag: master
 
 env:
   NEXT_PUBLIC_API_BASE_URL: https://api.yoma.world/api/v3
@@ -17,22 +17,26 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
+        if ($host = 'app.yoma.world') {
+          rewrite ^ https://yoma.world$request_uri permanent;
+        }
         if ($host = 'app.yoma.africa') {
-          rewrite ^ https://app.yoma.world$request_uri permanent;
+          rewrite ^ https://yoma.world$request_uri permanent;
         }
         if ($host = 'partner.yoma.world') {
-          rewrite ^ https://app.yoma.world$request_uri permanent;
+          rewrite ^ https://yoma.world$request_uri permanent;
         }
         if ($request_uri = '/register') {
-          rewrite ^ https://app.yoma.world permanent;
+          rewrite ^ https://yoma.world permanent;
         }
         if ($request_uri = '/login') {
-          rewrite ^ https://app.yoma.world permanent;
+          rewrite ^ https://yoma.world permanent;
         }
         if ($request_uri = '/employer/auth/login') {
-          rewrite ^ https://app.yoma.world permanent;
+          rewrite ^ https://yoma.world permanent;
         }
     rules:
+      - host: yoma.world
       - host: app.yoma.world
       - host: partner.yoma.world
       - host: app.yoma.africa
@@ -44,25 +48,29 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
+        if ($host = 'app.yoma.world') {
+          rewrite ^ https://yoma.world$request_uri permanent;
+        }
         if ($host = 'app.yoma.africa') {
-          rewrite ^ https://app.yoma.world$request_uri permanent;
+          rewrite ^ https://yoma.world$request_uri permanent;
         }
         if ($host = 'partner.yoma.world') {
-          rewrite ^ https://app.yoma.world$request_uri permanent;
+          rewrite ^ https://yoma.world$request_uri permanent;
         }
         if ($host = 'www.yoma.world') {
-          rewrite ^ https://app.yoma.world$request_uri permanent;
+          rewrite ^ https://yoma.world$request_uri permanent;
         }
         if ($request_uri = '/register') {
-          rewrite ^ https://app.yoma.world permanent;
+          rewrite ^ https://yoma.world permanent;
         }
         if ($request_uri = '/login') {
-          rewrite ^ https://app.yoma.world permanent;
+          rewrite ^ https://yoma.world permanent;
         }
         if ($request_uri = '/employer/auth/login') {
-          rewrite ^ https://app.yoma.world permanent;
+          rewrite ^ https://yoma.world permanent;
         }
     rules:
+      - host: yoma.world
       - host: app.yoma.world
       - host: partner.yoma.world
       - host: app.yoma.africa


### PR DESCRIPTION
* Drop the `app` subdomain from Yoma Web
* Migrate `auth.yoma.world` to `yoma.world/auth`

Relates to #733 