### PR TITLE
Partial revert of #698

### DIFF
--- a/helm/yoma-web/conf/base/secrets.yaml
+++ b/helm/yoma-web/conf/base/secrets.yaml
@@ -2,10 +2,6 @@ envSecret:
     NEXTAUTH_SECRET: ENC[AES256_GCM,data:L0d5tR9l7cGR5/jVC4CjqWQEvybEyJqE5BBEmrIwrMQ7,iv:hj15xg2Hkuy8AsJhHc1zBUv/7nYyCwltqld/IOS7dSk=,tag:KkWNHQpJShifLqoZuKQRyQ==,type:str]
     KEYCLOAK_CLIENT_ID: ENC[AES256_GCM,data:39QwfsLMsMQ=,iv:xwd1T2tACbGZh9vZ/BZYX+3rGy9FyihHOQsG2nzLeqM=,tag:mkYqwn4svK6SvoH5kxluoQ==,type:str]
     KEYCLOAK_CLIENT_SECRET: ENC[AES256_GCM,data:dU3bLyuP5l+2sXUszVosgAWwb+ypGStYv8v2soMs,iv:A55FX7KWHLgmWotJYt1YLQ8KCclBdZCK86mWDCLe2EM=,tag:gdt7T5ldUwzzHj0aME2oQg==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_ID: ENC[AES256_GCM,data:5iHAjC5N088=,iv:oWz9rOfkwIlPQ39STw7YUmYXiZSPq6DEMFR1lWhhaJ8=,tag:ksUFI519T8Nph4DAhMHcnw==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_SECRET: ENC[AES256_GCM,data:0XLCiTroAP8M6g7Kz9axa0bd3QZ8IU7oNqr/XFXY3w==,iv:GOlgO0NokC6vNhrvmD4VvGRzQ1L/05q3Le9JLwjm1vI=,tag:sFKjqSbHMKYlpV9T/hHjWw==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_ID: ENC[AES256_GCM,data:XdZnf5LI,iv:hFSKPMQJ23IXW9nLYYU7D9aAbdRH/XNWM6Q5fbBXGsw=,tag:Hu1YEfrC2enaMSsPbTiilg==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_SECRET: ENC[AES256_GCM,data:TEyXJEQLkgxiWeCc9/EHcyyA2S0VxetiFg8/0Yc=,iv:97+d9C0DBU1QQOH9pSphrpEDN3hFI0PzjwglydAaSKw=,tag:qfmBKapmiilUtl8WZHSjTA==,type:str]
     NEXTAUTH_URL: ENC[AES256_GCM,data:gVy7b/0PoIZ76iwXzL2zULWffM12Fw==,iv:m/6AHtuGjYw2+q/U5aDBHSqMRgJHhwJJwvPh+hVm5VU=,tag:u64ReLTZKsYNGvg89d/R0g==,type:str]
     API_BASE_URL: ENC[AES256_GCM,data:Dwwh1ZbfkUEryX9j827kxx5eVZJvbSpi3Wl0,iv:CiTQUPoztmL9KaQPFACwfsqQVLCizWu0doLho0mPqv0=,tag:1dyxnUT6eYAnWw3uzN1XYw==,type:str]
     KEYCLOAK_ISSUER: ENC[AES256_GCM,data:bC9j8VnY2HhNQ7ws20zT5j9vNpTctVP+E2Ooy2qjYipSiZC9wSuW,iv:txevfywgNOHQMNDEJ9T6PlFQnpV3v10WyQ7sTcjrSfM=,tag:r6P1IhuzKEUGSdnOrfYWBw==,type:str]
@@ -25,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-17T10:31:51Z"
-    mac: ENC[AES256_GCM,data:dL7/zwOhZw1KPrLCbY/9KM70SO8OjhLgNkXl4zBtUrwhrLkDsQtU8soiNGisgvNMDkypz2KRskPGoqpxSPtL45jc/qPL89MC1+aLwCw1ohu6+9+p8fNg9L7uNwkvIvdAInbavoySmFy6GWf+BJ5yD4zsdhM+jrghDLTTftFmges=,iv:jcuq3R62kzD9PHgBWOLpLklEGaPL+SAFrtmdYpF0Ru8=,tag:keAIU3baV/rvwkGAbEmLzQ==,type:str]
+    lastmodified: "2024-04-17T13:02:03Z"
+    mac: ENC[AES256_GCM,data:roAcNL+N+R1QUufAF1HIlAyP7zFH6ijxjLDG7dl2YMsKcKOGbXxwa0b/R3mD2UgluRKAJ/kvPj6ZyuOV5vnLFNS7bTRUixsvTC8QVUCWkurLVSvoIbFlbU4rIcubj4oJ9r4S1Ss419eqUwK7iFffBuJDdmjmaqYbKPMVFbXOGOQ=,iv:aQGz7yZU5rjKGkhHqn9GgOz8dsya1Q64j4I4OsUku48=,tag:ab1S2KzW4jmApcttsCfzFw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/helm/yoma-web/conf/dev/secrets.yaml
+++ b/helm/yoma-web/conf/dev/secrets.yaml
@@ -2,10 +2,6 @@ envSecret:
     NEXTAUTH_SECRET: ENC[AES256_GCM,data:2vPUi0yzBINJbgWwNqEsPGxJBS4jILJGzuEKPKGCJfeW,iv:GU+LgCx9fIRhvXYCAWX9M77CA7gGC8VG3eyR6bwMr5Q=,tag:dzoPkyw3IP0CDDxUTZD5dw==,type:str]
     KEYCLOAK_CLIENT_ID: ENC[AES256_GCM,data:DIG3RRbn2pc=,iv:12UbWoMYxk3Q/Dtw15eIBtT0bGtNPhzazbs7tXwTlHE=,tag:ZF2Il5T4WqWBpj2y1qq4MA==,type:str]
     KEYCLOAK_CLIENT_SECRET: ENC[AES256_GCM,data:LnHJRpSgd04w1n8w6bD3oFQZE+3Kow0pkyl3Tb9c,iv:m7eGpyhMP1MO+TCu/dqYJgNRxJRcWQjtKNyzffT6QH4=,tag:4OdkGPxCFRZTnzVUOHZC6w==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_ID: ENC[AES256_GCM,data:N+FJIGkkPsE=,iv:gLbNzv9etqiKBBEJmF+JFMKEBoYIAKcEVZn9biUmHsQ=,tag:Yhgbk1DhDQZtLPbZ1MMsGQ==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_SECRET: ENC[AES256_GCM,data:Zb4hyDHabULHSP+yvQaR54vxgjGOWwjeJBavieENLg==,iv:zYpJAw2wiJ+MPyjeW8EqgZcjse23YfJA04/ykBo7vXo=,tag:S2fWdOjEztc2WP8KK2sJaQ==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_ID: ENC[AES256_GCM,data:P8Iw2CtT,iv:GjRzP5r+0n1YIj88lNrowrvxoFLrCDyWfkZkm2ag42k=,tag:3yei1Se9W6hJNAjJfQcB5g==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_SECRET: ENC[AES256_GCM,data:a2/eLJozHj/IQj784L9lJ39/Nd+omNINSN+Q9gk=,iv:y07OlrUGICB2gzXzhfYX+AktleU6LxRb0oSWF8YzCeI=,tag:xhaDGtNU4VBH3a+6Cj618A==,type:str]
     NEXTAUTH_URL: ENC[AES256_GCM,data:bge3p4RlQmg9ASvr8BZlIlxs0feORg==,iv:UrUjONVpIXmM/UvVtIGc2hMqQ0+k7BHPdiQACk7u0ow=,tag:Cl/HIAKfGBVwf7yp6lTN3A==,type:str]
     API_BASE_URL: ENC[AES256_GCM,data:aVmqpzVQh0gNYd4hLe6/wDr453k37isBI/Lk,iv:2H7uvyIwFr8YHHXKRI5BadT0NZCJLKCS7uWSj8HpJPE=,tag:GTA++VrVWHZS7Nyolmr2DA==,type:str]
     KEYCLOAK_ISSUER: ENC[AES256_GCM,data:rDOoa4X4u6z1WAnN6MSKsSOWzLqs/X+Jw6r+jqnCb4QAYGm/Ghpl,iv:4oYIVzP3bEztsUvx6UGRGtnSp7OIP03X1uF5fxMKQcU=,tag:CjSCnMfO7TTpqWg8b9APWg==,type:str]
@@ -25,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-17T10:32:19Z"
-    mac: ENC[AES256_GCM,data:6xaS+psHb27QA1zBxDTBSdA5PJ60bLguD24BY43q49m01SP3Ks3+wsxG7FL4gsf/579wZjcMVpQaT5Pp4ZKJnxV35RoOrDKlDpl9t/hKyFuvKk9d+MC2qFNVizJWziRIdLZjCHndI6p7KPzzRq6Flb3YRM60+nCpnc46BEoT2jM=,iv:Kw2WY2bRUkI4Tob1K2J+X3BXN1LRLuptz5OcEIGk+dY=,tag:tC5q7n0owdD4hLc4Q1TLOw==,type:str]
+    lastmodified: "2024-04-17T13:02:17Z"
+    mac: ENC[AES256_GCM,data:HQpY++Vm6yElj5x4+dvY2tIi2JLadV2Xiw4BkkbOFzuasE+cvp16GoT4K4n9g0LOG+hajA+swktjUAerHHV7/TGLqhIorRNbXtj/AEFbAJhhdBxIcjglJE59AsEUx4CvGJ7Fz35vtaqPCjjcy4oSq22ODkSHbaPOTUu4se41lpg=,iv:Bey6x5UMxg7/UjkLGqylSh0P1RmxjyOcwTq7TG2aEyo=,tag:QVpuh6FOL+CbaS4avYFlUg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/helm/yoma-web/conf/prod/secrets.yaml
+++ b/helm/yoma-web/conf/prod/secrets.yaml
@@ -2,10 +2,6 @@ envSecret:
     NEXTAUTH_SECRET: ENC[AES256_GCM,data:MmcE7brrm2Ug2OqVb+YxnnyRotBAPQw7WJAX/7p1Xjg=,iv:7M+sMcZ1ft3aUoK3cK4QNl8mfPWhgQxyWzZ28bj6fL4=,tag:tuQmadxe+44sTlEYyu5ksg==,type:str]
     KEYCLOAK_CLIENT_ID: ENC[AES256_GCM,data:M7+DUh94un4=,iv:r0H9Kef5fyuJLHTGD9LZZaw/0g8EwQLJHwL7dqnqHiU=,tag:TTTrS5zA3f/AP/nIqVq0zQ==,type:str]
     KEYCLOAK_CLIENT_SECRET: ENC[AES256_GCM,data:Wd77l9bSlmzKp6PDV4mpH+VrFKvcnAuQYWNlBLYNqzXU8yKlgK6NC9zfk8Br+XuLAfGkimUYQaepYJx/0ZnA6g==,iv:m9X6VQKvYdfeH6Ta3adRAMylYdBoAjPAbNUsd/6cziU=,tag:pYa0EDRKUyY2tslccqS1Ww==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_ID: ENC[AES256_GCM,data:Ox27iBUWwog=,iv:qdflQm772Q8gGgZ3997GaWmaF9wyf/tC3GOOlqcfM+Q=,tag:RdhBS+lyjzG1eUQy1sONHA==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_SECRET: ENC[AES256_GCM,data:4NCcgdfujJTc/whMBKnkJh1uLyuH0FbJWaVmn00286Sc7Bs16P0Tyz+LMoNvAYzxCjxvog7jOem87oIIUTGm6w==,iv:Q2Ms/DcyMPieZtSpEKi3iEzbHCaINv+Ta3aIL8jOa+A=,tag:9uEgwXyDH08ahHfhsBS3BA==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_ID: ENC[AES256_GCM,data:5HJJTrAi,iv:rEJ0l/6OULCU8H0JktVq6OnBngvMnzoGKJhDNPQ/uFk=,tag:n1TnaQEi/q19u7tnYmIA4w==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_SECRET: ENC[AES256_GCM,data:hsJKTCajhdXynkjjtksui7srdcNkA7Vtgo9FqUXo35acCc0G+vN8WmTozwfaAYoDjPqG7KO9NlLsYFzXVOkHpQ==,iv:GxpIDAT2oy1nId/jdCUuA84SaUDIDWUkalz5J98EeQU=,tag:VeC2i2jxT9jChH7dC4Qqng==,type:str]
     NEXTAUTH_URL: ENC[AES256_GCM,data:sF/lGL+dwCpzgljcoImu3zZPKj09Iw==,iv:Y1reaaVf4LaYzaDCg2NNvO0fsKugOCP2w/MbAbcRfkk=,tag:1NfOJIE+Dzp7Rwvd9N27Ig==,type:str]
     API_BASE_URL: ENC[AES256_GCM,data:pL3RxaZ6Z2VxtIld/xJJUU7yKwt5pVtftW3h,iv:nIvKD2F+JVTyfbhLysqciNvn/gJ5XmGHPncnLnA3kDQ=,tag:OrEh8A0c8RPenyqhnSqeUA==,type:str]
     KEYCLOAK_ISSUER: ENC[AES256_GCM,data:5Izgw0A6pEzqTzI3PGQgtYLCuVY5GkYHyVMG8UGR+gd9Iyo=,iv:Krp7wjQuX2QTqk7IfZSrKcD0+1cl5Ut/oeIWVWrh22c=,tag:MOpUe6JlE5tpVsPL6C3FQg==,type:str]
@@ -25,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-09T08:57:46Z"
-    mac: ENC[AES256_GCM,data:nza/X/+0vepiO048Hrkn+PfGtaE+I7i5W0AHGVu/125eqMKYV4Ogqs1+sF1XK73qqTvAD/I0TswNf76dhpAuY74X2lo6WpVAi8/Q5AkHV1GBQMQ4819ipuy71LrAFbzJZXM+pqBQwYgAJc+jITCAng5ZWDdGnVLrrSOaYNYdNYU=,iv:QW/3GQJSuaCJJvJzKYLCQ0deF8z7C9HxSiTaTcF/6Mk=,tag:bgh6XwRd8AUKytZOsUNvSg==,type:str]
+    lastmodified: "2024-04-17T13:02:40Z"
+    mac: ENC[AES256_GCM,data:mElyjEyp4d4yvEPTP6G3ey08EfM+UEBYIYODrRLuaTi7J7squVccKHbcHolLWHWop2pJIEb8Yh3UZJaSERND6u+yTtx0iwFnq88KtdGMcYZXgNOQaUFh2RuFnwL9+xh2lG88DBGr4hF0vxBhv5Mi1k79w7tEEfaQEx3oMg+3WnE=,iv:i61mNb0KxghGqRo5BN9PG7IMIiCtuULXJ2Xd/iGuyQg=,tag:EVkx5ZoiH1SNC1Q5zxufJA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/helm/yoma-web/conf/stage/secrets.yaml
+++ b/helm/yoma-web/conf/stage/secrets.yaml
@@ -2,10 +2,6 @@ envSecret:
     NEXTAUTH_SECRET: ENC[AES256_GCM,data:0OejkBtLgG+NPGIwxaQXtvInbGYypuJt9Imdn3Zdjz/5,iv:bxLasSh8TJ+sCVpkazIhwdhp1UNntNiT+jzGDK+MD2o=,tag:+uw4iWRaJNe6RZpFQRVhaw==,type:str]
     KEYCLOAK_CLIENT_ID: ENC[AES256_GCM,data:2Yj1TN0jOEQ=,iv:BOPeylMWtw5cKOkw3YQSa3C+BKzNRmklarFRQfJKCWI=,tag:wA6f+vrOEVuTWeyGKEKYTQ==,type:str]
     KEYCLOAK_CLIENT_SECRET: ENC[AES256_GCM,data:s4PQopo00Nyh+YjwtsD7UVMbivovenMemN87mLS4rgk=,iv:v/RtVCgfmYa2kARqaIkqo2TLGuqRty9Fx1UuBjUqmJQ=,tag:rIoNxAA9GpFExQiwkiXi2g==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_ID: ENC[AES256_GCM,data:cRYJDu+/3n4=,iv:x4qdXL0rAirCFVyyYaWWr2pRzcqcBC2nnTf1j7GY35w=,tag:+oAtMAXB/Im/KyQTIIjPTQ==,type:str]
-    KEYCLOAK_GOODWALL_CLIENT_SECRET: ENC[AES256_GCM,data:RTz0pmVXMymSSVGwyt8LGrfF32GYRBKKC6036YtN1ro=,iv:fvZEBEJ+DJCF5HvhaNw1bsQQ59j0A45o/wlyqGNWHio=,tag:Vdl9yzOSgKKIV+BHtKxzxw==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_ID: ENC[AES256_GCM,data:fxKXepVv,iv:0qE3y5otFCXxQZT8AJPfoysNbkK48vVFb8RiYKfcYBs=,tag:LEi6XIoUQsDULfGABZ1Jsw==,type:str]
-    KEYCLOAK_ATINGI_CLIENT_SECRET: ENC[AES256_GCM,data:fnpRzpLahA/gSJJafkL3TzRSOQKzMYDasd4NSRv0glQ=,iv:3keZNwWel04Ti61vHGbxfuFdOCcVu/L8LLcaiHa32BE=,tag:mtXAY3XzI0zqr3lVw2Fxcw==,type:str]
     NEXTAUTH_URL: ENC[AES256_GCM,data:xNEme8uPYjqD/198lMALPisA0NLFqH+f,iv:BTvvP+ly1om2uFcwvOilStSO6ilqFFNnB8pJDRA6pLI=,tag:UUB7UAzErDWfrfxLfVWR8A==,type:str]
     API_BASE_URL: ENC[AES256_GCM,data:NPOcwhYvqvcwL18cvzK+DxVyKqBGLdla94hM,iv:LRfUBWQSb9LpEDPPg3f514aOVE01fxgodFk3LttjbK8=,tag:b9BhKDEu3sXm6Xfx/ue34Q==,type:str]
     KEYCLOAK_ISSUER: ENC[AES256_GCM,data:zpodP/N3qkBoTa8kHkRY0dn3RgHzyZhyjmhBY9JRKBqg1LEZ7/ib1mw=,iv:7nd1D5y6q+lQB4NlfbQXXL4G80v0LK/xwHwrHN1HPRQ=,tag:aaSiQzRJFALvAxrNUbB5nw==,type:str]
@@ -25,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-17T10:32:54Z"
-    mac: ENC[AES256_GCM,data:MakvkOdZrPCaqAD4iJkDB6hT/eAmuvsUMyEspDK7Kgm0ayPHgzTcFleZgpZKVdTqHZ03yczGapFo+7cEOPHoViVS5mVOPSZoP/15TSA0qd1UpyUiqnzU1N1W8FzCuBI80tthvZDHeHn37acZoDrIZPcULAOaftMv7zQq14BYGVI=,iv:drNElGzKbiSbU/n0cHj0wNxlWwrWLU0lNmFcB/rtFCo=,tag:eWk5XLQ2Ex7Mi/Kvc1hu0g==,type:str]
+    lastmodified: "2024-04-17T13:02:28Z"
+    mac: ENC[AES256_GCM,data:NVHJTbmpTteceej7IBkTL3v67pJipotUfqv2TiLPLNHkz53fHBRjwRYJKPeviyVfZVeMCH3WEf+LhMfa+d3d1MxnkctDJEDDtdnhIRGALhl4ViElj8WX327xNzx0kZV6OH3RJykTW7aDqXsQrqrXbXz7nZdBriVNEjpxtKmFrfs=,iv:BnjBbsoz/tgOQq6DnmMdd1HLttGERnXKS/JkZNauMPU=,tag:RsKumioME9Tbmt6cOWE5iw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/src/keycloak/exports/01-yoma-realm.yaml
+++ b/src/keycloak/exports/01-yoma-realm.yaml
@@ -527,23 +527,21 @@ clients:
     redirectUris:
       - "/*"
       - $(env:CLIENT_ATINGI_URL_REDIRECT)
-      - $(env:CLIENT_YOMA_WEB_URL)/*
     webOrigins:
       - $(env:CLIENT_ATINGI_URL)
-      - $(env:CLIENT_YOMA_WEB_URL)
     notBefore: 0
     bearerOnly: false
     consentRequired: false
     standardFlowEnabled: true
     implicitFlowEnabled: false
-    directAccessGrantsEnabled: true
-    serviceAccountsEnabled: true
+    directAccessGrantsEnabled: false
+    serviceAccountsEnabled: false
     publicClient: false
     frontchannelLogout: true
     protocol: openid-connect
     attributes:
       oidc.ciba.grant.enabled: "false"
-      post.logout.redirect.uris: $(env:CLIENT_ATINGI_URL)/*##$(env:CLIENT_ATINGI_URL_POST_LOGOUT_REDIRECT)/*##$(env:CLIENT_YOMA_WEB_URL)/*
+      post.logout.redirect.uris: $(env:CLIENT_ATINGI_URL)/*##$(env:CLIENT_ATINGI_URL_POST_LOGOUT_REDIRECT)/*
       oauth2.device.authorization.grant.enabled: "false"
       backchannel.logout.session.required: "true"
       backchannel.logout.revoke.offline.tokens: "false"
@@ -579,23 +577,21 @@ clients:
     redirectUris:
       - "/*"
       - $(env:CLIENT_GOODWALL_URL_REDIRECT)
-      - $(env:CLIENT_YOMA_WEB_URL)/*
     webOrigins:
       - $(env:CLIENT_GOODWALL_URL)
-      - $(env:CLIENT_YOMA_WEB_URL)
     notBefore: 0
     bearerOnly: false
     consentRequired: false
     standardFlowEnabled: true
     implicitFlowEnabled: false
-    directAccessGrantsEnabled: true
-    serviceAccountsEnabled: true
+    directAccessGrantsEnabled: false
+    serviceAccountsEnabled: false
     publicClient: false
     frontchannelLogout: true
     protocol: openid-connect
     attributes:
       oidc.ciba.grant.enabled: "false"
-      post.logout.redirect.uris: $(env:CLIENT_GOODWALL_URL)/*##$(env:CLIENT_YOMA_WEB_URL)/*
+      post.logout.redirect.uris: $(env:CLIENT_GOODWALL_URL)/*
       oauth2.device.authorization.grant.enabled: "false"
       backchannel.logout.session.required: "true"
       backchannel.logout.revoke.offline.tokens: "false"


### PR DESCRIPTION
Partially reverts #698 

---

* Goodwall and Atingi clients don't need Direct Access Grants or Service
Accounts
* Yoma Web is no longer using Goodwall/Atingi clients as auth providers,
so remove Yoma Web URL from them