### PR TITLE
Increase Nginx Proxy Buffer for Yoma Web Ingresses

### DIFF
--- a/helm/yoma-web/conf/dev/values.yaml
+++ b/helm/yoma-web/conf/dev/values.yaml
@@ -12,6 +12,8 @@ env:
 ingress:
   internal:
     annotations:
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     rules:
       - host: dev.yoma.world

--- a/helm/yoma-web/conf/dev/values.yaml
+++ b/helm/yoma-web/conf/dev/values.yaml
@@ -15,5 +15,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
     rules:
       - host: dev.yoma.world

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -12,6 +12,8 @@ env:
 ingress:
   internal:
     annotations:
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.africa') {
@@ -36,6 +38,8 @@ ingress:
   external:
     enabled: true
     annotations:
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.africa') {

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -15,6 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.africa') {
           rewrite ^ https://app.yoma.world$request_uri permanent;
@@ -41,6 +42,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.africa') {
           rewrite ^ https://app.yoma.world$request_uri permanent;

--- a/helm/yoma-web/conf/stage/values.yaml
+++ b/helm/yoma-web/conf/stage/values.yaml
@@ -12,12 +12,16 @@ env:
 ingress:
   internal:
     annotations:
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     rules:
       - host: stage.yoma.world
   external:
     enabled: true
     annotations:
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     rules:
       - host: stage.yoma.world

--- a/helm/yoma-web/conf/stage/values.yaml
+++ b/helm/yoma-web/conf/stage/values.yaml
@@ -15,6 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
     rules:
       - host: stage.yoma.world
   external:
@@ -23,5 +24,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 32k;
     rules:
       - host: stage.yoma.world


### PR DESCRIPTION
* Increase default `large_client_header_buffers 4 8k` to `8 32k`
  * Nginx [`large_client_header_buffers`](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
  * Ingress Nginx [`large-client-header-buffers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#large-client-header-buffers)
* Enable Proxy Buffering
  * [nginx.ingress.kubernetes.io/proxy-buffering](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-buffering)
* Increase Number of Proxy Buffers from `4` to `8`
  * [nginx.ingress.kubernetes.io/proxy-buffers-number](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-buffers-number)

---

> Syntax: large_client_header_buffers number size;
> Default: large_client_header_buffers 4 8k;
> Context: http, server
>
> Sets the maximum number and size of buffers used for reading large client request header. A request line cannot exceed the size of one buffer, or the 414 (Request-URI Too Large) error is returned to the client. A request header field cannot exceed the size of one buffer as well, or the 400 (Bad Request) error is returned to the client. Buffers are allocated only on demand. By default, the buffer size is equal to 8K bytes. If after the end of request processing a connection is transitioned into the keep-alive state, these buffers are released.

---

Closes YOMA-79