### PR TITLE
Hotfix: Fix Deploy Concurrency Group

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -342,7 +342,7 @@ jobs:
       TAG: ${{ needs.build.outputs.image_version }}
 
     concurrency:
-      group: ${{ github.workflow }}-deploy-${{ vars.ENVIRONMENT }}
+      group: ${{ github.workflow }}-deploy-${{ github.event_name == 'release' && 'prod' || (github.event_name == 'push' && github.event.repository.default_branch == github.ref_name) && 'stage' || 'dev' }}
       cancel-in-progress: false
     environment:
       name: ${{


### PR DESCRIPTION
`vars.ENVIRONMENT` wasn't resolving because it's an environment
(dev|stage|prod) specific variable and it's not resolvable when the
concurrency group is being set