### PR TITLE
Fix deploy fresh dbs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -427,6 +427,8 @@ jobs:
               --selector=app=postgresql-keycloak \
               --selector=app=postgresql \
               --selector=app=redis
+          helmfile-version: ${{ env.HELMFILE_VERSION }}
+          helm-version: ${{ env.HELM_VERSION }}
           helm-plugins: |
             https://github.com/databus23/helm-diff,
             https://github.com/jkroepke/helm-secrets,


### PR DESCRIPTION
* Helmfile and Helm versions weren't pinned in Deploy Fresh DBs step
* Helmfile `1.0.0-rc1` has breaking changes which causes our helmfile to break