### PR TITLE
Allow link end date set to today as valid if created before midnight UTC

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/ActionLink/Validators/LinkRequestCreateValidatorVerify.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/ActionLink/Validators/LinkRequestCreateValidatorVerify.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Yoma.Core.Domain.ActionLink.Models;
+using Yoma.Core.Domain.Core.Extensions;
 
 namespace Yoma.Core.Domain.ActionLink.Validators
 {
@@ -32,7 +33,7 @@ namespace Yoma.Core.Domain.ActionLink.Validators
         .WithMessage("'Distribution List' contain(s) empty or invalid email address(es).");
         });
 
-      RuleFor(x => x.DateEnd).Must(date => !date.HasValue || date.Value > DateTimeOffset.UtcNow).WithMessage("'{PropertyName}' must be in the future.");
+      RuleFor(x => x.DateEnd).Must(date => !date.HasValue || date.Value.ToEndOfDay() > DateTimeOffset.UtcNow).WithMessage("'{PropertyName}' must be in the future.");
     }
     #endregion
   }

--- a/src/api/src/domain/Yoma.Core.Domain/Analytics/Services/AnalyticsService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Analytics/Services/AnalyticsService.cs
@@ -232,15 +232,15 @@ namespace Yoma.Core.Domain.Analytics.Services
       result.Opportunities.Completion = new OpportunityCompletion { Legend = "Average time (days)", AverageTimeInDays = (int)Math.Round(averageCompletionTimeInDays) };
 
       //average conversation rate
-      var items = SearchOrganizationOpportunitiesQueryBase(new OrganizationSearchFilterOpportunity
-      {
-        Organization = filter.Organization,
-        Opportunities = filter.Opportunities,
-        Categories = filter.Categories,
-        StartDate = filter.StartDate,
-        EndDate = filter.EndDate
+      //var items = SearchOrganizationOpportunitiesQueryBase(new OrganizationSearchFilterOpportunity
+      //{
+      //  Organization = filter.Organization,
+      //  Opportunities = filter.Opportunities,
+      //  Categories = filter.Categories,
+      //  StartDate = filter.StartDate,
+      //  EndDate = filter.EndDate
 
-      }).ToList();
+      //}).ToList();
 
       result.Opportunities.ConversionRate = new OpportunityConversionRatio
       {
@@ -248,9 +248,10 @@ namespace Yoma.Core.Domain.Analytics.Services
         ViewedCount = viewedCount,
         CompletedCount = completedCount,
         //calculate average percentage based on individual opportunity conversion ratio rather than global counts (more accurate)
-        Percentage = items.Count != 0
-              ? Math.Min(100M, Math.Round(items.Sum(o => o.ConversionRatioPercentage) / items.Count))
-              : 0M
+        Percentage = viewedCount > 0 ? Math.Min(100M, Math.Round((decimal)completedCount / viewedCount * 100, 2)) : 0
+        //Percentage = items.Count != 0
+        //      ? Math.Min(100M, Math.Round(items.Sum(o => o.ConversionRatioPercentage) / items.Count))
+        //      : 0M
       };
 
       //zlto rewards


### PR DESCRIPTION
Update average conversion rate calculation to reflect viewed/completed counts from filtered engagement