### PR TITLE
Increase Resource Requests and Limits

### DIFF
--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -31,11 +31,11 @@ keycloak:
   replicas: 2
   resources:
     requests:
-      cpu: 10m
-      memory: 1024Mi
+      cpu: 100m
+      memory: 1536Mi
     limits:
-      cpu: 2500m
-      memory: 1024Mi
+      cpu: 4000m
+      memory: 1536Mi
 
   themes:
     enabled: true

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -233,6 +233,7 @@ keycloak:
       value: >-
         -XX:+UseContainerSupport
         -XX:MaxRAMPercentage=75.0
+        -Xmx{{ .Values.resources.limits.memory | lower | replace "mi" "" }}m
         -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
         -Djava.awt.headless=true
         -Dkeycloak.profile.feature.upload_scripts=enabled
@@ -334,6 +335,7 @@ keycloak:
       memory: 1536Mi
     limits:
       cpu: 3000m
+      # This must _always_ be in `Mi` to calculate the max JVM size
       memory: 1536Mi
 
   extraVolumes: |-

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -232,7 +232,7 @@ keycloak:
     - name: JAVA_OPTS_APPEND
       value: >-
         -XX:+UseContainerSupport
-        -XX:MaxRAMPercentage=50.0
+        -XX:MaxRAMPercentage=75.0
         -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
         -Djava.awt.headless=true
         -Dkeycloak.profile.feature.upload_scripts=enabled

--- a/helm/yoma-api/conf/prod/values.yaml
+++ b/helm/yoma-api/conf/prod/values.yaml
@@ -53,5 +53,5 @@ resources:
     cpu: 100m
     memory: 1024Mi
   limits:
-    cpu: 2000m
+    cpu: 2500m
     memory: 1024Mi

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -75,3 +75,11 @@ ingress:
       - host: partner.yoma.world
       - host: app.yoma.africa
       - host: www.yoma.world
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/helm/yoma-web/values.yaml
+++ b/helm/yoma-web/values.yaml
@@ -72,17 +72,17 @@ ingress:
           - path: /
             port: 8000
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
* Yoma Web
  * By default, request 50mvCPU, 128Mi Memory
  * Prod, double it - 100mvCPU request and 500mvCPU limit. 256Mi Memory Req/Limit
* Yoma API
  * Increase CPU Limit from 2vCPU to 2.5vCPU
* Keycloak
  * Increase Memory from 1Gi to 1.5Gi
  * Increase CPU Request to 100mvCPU
  * Increase CPU Limit to 4vCPU
  * Increase JVM Max RAM Percentage from 50% to 75%
  * Use Helm Templating to calculate `-Xmx` value based of `resources.limits.memory`
    * According to GPT, specifying both `-XX:MaxRAMPercentage` and `-Xmx`, the JVM will use whichever is the _lower_ value