### PR TITLE
Bump Yoma Web Memory Request/Limits

### DIFF
--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -79,7 +79,7 @@ ingress:
 resources:
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
   limits:
     cpu: 500m
-    memory: 256Mi
+    memory: 512Mi

--- a/helm/yoma-web/values.yaml
+++ b/helm/yoma-web/values.yaml
@@ -79,10 +79,10 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
     cpu: 50m
-    memory: 128Mi
+    memory: 256Mi
   limits:
     cpu: 250m
-    memory: 128Mi
+    memory: 256Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
* Yoma Web in Stage was memory starved causing pods to crash when trying
to log in