### PR TITLE
Bump Yoma Web and Keycloak resources

### DIFF
--- a/helm/keycloak/conf/dev/values.yaml
+++ b/helm/keycloak/conf/dev/values.yaml
@@ -23,13 +23,6 @@ postInstallHook:
 
 keycloak:
   replicas: 2
-  resources:
-    requests:
-      cpu: 10m
-      memory: 512Mi
-    limits:
-      cpu: 2500m
-      memory: 512Mi
 
   themes:
     enabled: true

--- a/helm/keycloak/conf/stage/values.yaml
+++ b/helm/keycloak/conf/stage/values.yaml
@@ -23,13 +23,6 @@ postInstallHook:
 
 keycloak:
   replicas: 2
-  resources:
-    requests:
-      cpu: 10m
-      memory: 512Mi
-    limits:
-      cpu: 2500m
-      memory: 512Mi
 
   themes:
     enabled: true

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -331,12 +331,12 @@ keycloak:
 
   resources:
     requests:
-      cpu: 500m
-      memory: 1536Mi
+      cpu: 100m
+      memory: 768Mi
     limits:
       cpu: 3000m
       # This must _always_ be in `Mi` to calculate the max JVM size
-      memory: 1536Mi
+      memory: 768Mi
 
   extraVolumes: |-
     - name: providers

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -81,5 +81,5 @@ resources:
     cpu: 100m
     memory: 384Mi
   limits:
-    cpu: 500m
+    cpu: 2000m
     memory: 384Mi

--- a/helm/yoma-web/values.yaml
+++ b/helm/yoma-web/values.yaml
@@ -79,10 +79,10 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
     cpu: 50m
-    memory: 256Mi
+    memory: 386Mi
   limits:
-    cpu: 250m
-    memory: 256Mi
+    cpu: 500m
+    memory: 386Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
* Bump Yoma Web Memory from 256Mi to 386Mi
* Bump Keycloak Memory from 512Mi to 768Mi, increase CPU from 50m to 100m request

---

Relates to YOMA-176