### PR TITLE
Time interval ordering and opportunity end date validation

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/Lookups/Helpers/TimeIntervalHelper.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Lookups/Helpers/TimeIntervalHelper.cs
@@ -1,0 +1,24 @@
+using Yoma.Core.Domain.Core;
+
+namespace Yoma.Core.Domain.Lookups.Helpers
+{
+  public static class TimeIntervalHelper
+  {
+    public static int GetOrder(string intervalAsString)
+    {
+      if (Enum.TryParse<TimeInterval>(intervalAsString, out var interval))
+      {
+        return interval switch
+        {
+          TimeInterval.Minute => 1,
+          TimeInterval.Hour => 2,
+          TimeInterval.Day => 3,
+          TimeInterval.Week => 4,
+          TimeInterval.Month => 5,
+          _ => throw new InvalidOperationException($"{nameof(TimeInterval)} of '{interval}' not supported"),
+        };
+      }
+      throw new InvalidOperationException($"Invalid TimeInterval name '{intervalAsString}'");
+    }
+  }
+}

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
@@ -1024,7 +1024,7 @@ namespace Yoma.Core.Domain.Opportunity.Services
       if (result.DateEnd.HasValue)
       {
         var commitmentIntervalInDays = result.TimeIntervalToDays();
-        var dateEndMin = result.DateStart.AddDays(commitmentIntervalInDays);
+        var dateEndMin = result.DateStart.AddDays(commitmentIntervalInDays - 1); //count today as the 1st day
         if (dateEndMin > result.DateEnd.Value)
           throw new ValidationException($"The end date for the opportunity must be on or after {dateEndMin.Date}, based on the specified start date and commitment interval");
       }

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Migrations/20240522063953_ApplicationDb_Featured_Types_Intervals_Seeding.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Migrations/20240522063953_ApplicationDb_Featured_Types_Intervals_Seeding.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore.Migrations;
-using Microsoft.Extensions.Logging;
 
 namespace Yoma.Core.Infrastructure.Database.Migrations
 {


### PR DESCRIPTION
Added custom ordering for TimeInterval based on interval duration. Ordered with the least interval first: Minutes, Hours, Days, Weeks, Months

Opportunity end date validation: Today is now included. So if the duration based on the commitment interval is 1, the opportunity can start end end on the same day