### PR TITLE
Bump Deploy dependencies, don't lint on release

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,6 +33,8 @@ jobs:
       group: ${{ github.workflow }}-lint-${{ matrix.project }}-${{ github.ref }}
       cancel-in-progress: true
 
+    if: github.event_name != 'release'
+
     strategy:
       fail-fast: false
       matrix:
@@ -336,9 +338,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TAILSCALE_VERSION: 1.64.0
-      HELMFILE_VERSION: v0.163.1
-      HELM_VERSION: v3.14.4
+      TAILSCALE_VERSION: 1.68.0
+      HELMFILE_VERSION: v0.165.0
+      HELM_VERSION: v3.15.2
       TAG: ${{ needs.build.outputs.image_version }}
 
     concurrency:


### PR DESCRIPTION
During the release to Vercel it was noted that Lint doesn't support Release actions.

So I've added a condition to the Lint step that will skip it if it's a github release.

https://github.com/didx-xyz/yoma/actions/runs/9462473678/job/26065520951
```
Error: lint-action does not support "release" GitHub events
```
![image](https://github.com/didx-xyz/yoma/assets/4052340/186a0b3c-146e-4f36-b3ee-cb75596492e5)

---

* Tailscale `1.64.0` -> `1.68.0`
* Helmfile `0.163.1` -> `0.165.0`
* Helm `3.14.4` -> `3.15.2`