### PR TITLE
Yoma API Probes

### DIFF
--- a/helm/yoma-api/templates/deployment.yaml
+++ b/helm/yoma-api/templates/deployment.yaml
@@ -64,12 +64,33 @@ spec:
             httpGet:
               path: /api/v3/health/live
               port: {{ .Values.service.portName | default "http"  }}
+            initialDelaySeconds: {{ default 0 .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ default 10 .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ default 3 .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ default 1 .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ default 1 .Values.livenessProbe.timeoutSeconds }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/v3/health/ready
               port: {{ .Values.service.portName | default "http"  }}
+            initialDelaySeconds: {{ default 0 .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ default 10 .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ default 3 .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ default 1 .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ default 1 .Values.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/v3/health/live
+              port: {{ .Values.service.portName | default "http"  }}
+            initialDelaySeconds: {{ default 0 .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ default 10 .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ default 3 .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ default 1 .Values.startupProbe.successThreshold }}
+            timeoutSeconds: {{ default 1 .Values.startupProbe.timeoutSeconds }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -183,6 +183,12 @@ readinessProbe:
   enabled: true
 livenessProbe:
   enabled: true
+startupProbe:
+  enabled: true
+  periodSeconds: 10
+  failureThreshold: 30
+  successThreshold: 1
+  timeoutSeconds: 3
 
 podDisruptionBudget:
   enabled: false


### PR DESCRIPTION
* Flesh out the health probes a bit
* Add startup probe to protect instances where migrations could take
a while to run preventing the liveness probe from passing