### PR TITLE
Yoma API HPA, PDB, Pre-Stop, better health probes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -336,9 +336,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TAILSCALE_VERSION: 1.68.0
-      HELMFILE_VERSION: v0.165.0
-      HELM_VERSION: v3.15.2
+      TAILSCALE_VERSION: 1.72.1
+      HELMFILE_VERSION: v0.167.1
+      HELM_VERSION: v3.15.4
       TAG: ${{ needs.build.outputs.image_version }}
 
     concurrency:

--- a/helm/keycloak/Chart.lock
+++ b/helm/keycloak/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.3
+  version: 2.22.0
 - name: keycloakx
   repository: https://codecentric.github.io/helm-charts
   version: 2.2.2
 - name: keycloak-config-cli
   repository: git+https://github.com/didx-xyz/keycloak-config-cli@contrib/charts?ref=init-containers&sparse=0
   version: 5.8.1-SNAPSHOT
-digest: sha256:5005b9a70b9666d8cafe2e2a5d87eb135ce43c78693f3ebdd04c2a8814e37ecd
-generated: "2023-11-10T16:21:18.435932+02:00"
+digest: sha256:2ca0168754e5e4576697f30aec57c998a203324e375ef139eea37e5d3b4a474e
+generated: "2024-08-27T16:16:23.167974+02:00"

--- a/helm/keycloak/Chart.yaml
+++ b/helm/keycloak/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: keycloak
 description: A Wrapper Helm chart for Keycloakx in Kubernetes
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 22.0.1
 
 dependencies:
   - name: common
-    version: 2.13.3
+    version: 2.x.x
     repository: oci://registry-1.docker.io/bitnamicharts
 
   # https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -328,8 +328,16 @@ keycloak:
     admission.datadoghq.com/enabled: "false" # disabled by default (for now)
   podAnnotations:
     # gcr.io/datadoghq/dd-lib-java-init
-    admission.datadoghq.com/java-lib.version: v1.38.0
+    admission.datadoghq.com/java-lib.version: v1.38.1
     ad.datadoghq.com/keycloak.logs: '[{ "service": "keycloak", "source": "jboss_wildfly" }]'
+
+  lifecycleHooks: |
+    preStop:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - sleep 5
 
   resources:
     requests:

--- a/helm/yoma-api/Chart.lock
+++ b/helm/yoma-api/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.22.0
+digest: sha256:e66b153d2c35ef24ff65f0e17b63643843360e98a69ddfcd99b38befe00e6c37
+generated: "2024-08-27T15:13:37.79633+02:00"

--- a/helm/yoma-api/Chart.yaml
+++ b/helm/yoma-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yoma
-description: A Helm chart for Kubernetes
+description: A Helm chart to deploy Yoma on Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -22,3 +22,8 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: 3.x.x
+
+dependencies:
+  - name: common
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/helm/yoma-api/conf/prod/values.yaml
+++ b/helm/yoma-api/conf/prod/values.yaml
@@ -57,5 +57,14 @@ resources:
     cpu: 100m
     memory: 1024Mi
   limits:
-    cpu: 2500m
+    cpu: 2000m
     memory: 1024Mi
+
+autoscaling:
+  enabled: true
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 200
+  # targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true

--- a/helm/yoma-api/conf/stage/values.yaml
+++ b/helm/yoma-api/conf/stage/values.yaml
@@ -57,5 +57,14 @@ resources:
     cpu: 100m
     memory: 512Mi
   limits:
-    cpu: 2000m
+    cpu: 1000m
     memory: 512Mi
+
+autoscaling:
+  enabled: true
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 200
+  # targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true

--- a/helm/yoma-api/templates/_helpers.tpl
+++ b/helm/yoma-api/templates/_helpers.tpl
@@ -24,33 +24,6 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "yoma-api.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "yoma-api.labels" -}}
-yoma-api.sh/chart: {{ include "yoma-api.chart" . }}
-{{ include "yoma-api.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "yoma-api.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "yoma-api.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
 Create the name of the service account to use
 */}}
 {{- define "yoma-api.serviceAccountName" -}}
@@ -60,44 +33,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-
-{{/*
-Copyright VMware, Inc.
-SPDX-License-Identifier: APACHE-2.0
-https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_tplvalues.tpl
-*/}}
-
-{{/* vim: set filetype=mustache: */}}
-{{/*
-Renders a value that contains template perhaps with scope if the scope is present.
-Usage:
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
-*/}}
-{{- define "common.tplvalues.render" -}}
-{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
-{{- if contains "{{" (toJson .value) }}
-  {{- if .scope }}
-      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
-  {{- else }}
-    {{- tpl $value .context }}
-  {{- end }}
-{{- else }}
-    {{- $value }}
-{{- end }}
-{{- end -}}
-
-{{/*
-Merge a list of values that contains template after rendering them.
-Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
-Usage:
-{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
-*/}}
-{{- define "common.tplvalues.merge" -}}
-{{- $dst := dict -}}
-{{- range .values -}}
-{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
-{{- end -}}
-{{ $dst | toYaml }}
-{{- end -}}

--- a/helm/yoma-api/templates/deployment.yaml
+++ b/helm/yoma-api/templates/deployment.yaml
@@ -2,8 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "yoma-api.fullname" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- with .Values.deploymentLabels }}
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
@@ -11,9 +10,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
-    matchLabels:
-      {{- include "yoma-api.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -21,11 +20,7 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      labels:
-        {{- include "yoma-api.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- tpl (toYaml .) $ | nindent 8 }}
-        {{- end }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -100,9 +95,13 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
       affinity:
-        {{- tpl (toYaml .) $ | nindent 8 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "customLabels" $podLabels "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "customLabels" $podLabels "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/helm/yoma-api/templates/deployment.yaml
+++ b/helm/yoma-api/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.command }}
           command:
             {{- toYaml .Values.command | nindent 12 }}
@@ -59,38 +62,17 @@ spec:
               containerPort: {{ $v.port }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
+          {{- if .Values.livenessProbe.enabled}}
           livenessProbe:
-            httpGet:
-              path: /api/v3/health/live
-              port: {{ .Values.service.portName | default "http"  }}
-            initialDelaySeconds: {{ default 0 .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ default 10 .Values.livenessProbe.periodSeconds }}
-            failureThreshold: {{ default 3 .Values.livenessProbe.failureThreshold }}
-            successThreshold: {{ default 1 .Values.livenessProbe.successThreshold }}
-            timeoutSeconds: {{ default 1 .Values.livenessProbe.timeoutSeconds }}
+            {{- tpl (toYaml (omit .Values.livenessProbe "enabled")) . | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+          {{- if .Values.readinessProbe.enabled}}
           readinessProbe:
-            httpGet:
-              path: /api/v3/health/ready
-              port: {{ .Values.service.portName | default "http"  }}
-            initialDelaySeconds: {{ default 0 .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ default 10 .Values.readinessProbe.periodSeconds }}
-            failureThreshold: {{ default 3 .Values.readinessProbe.failureThreshold }}
-            successThreshold: {{ default 1 .Values.readinessProbe.successThreshold }}
-            timeoutSeconds: {{ default 1 .Values.readinessProbe.timeoutSeconds }}
+            {{- tpl (toYaml (omit .Values.readinessProbe "enabled")) . | nindent 12 }}
           {{- end }}
-          {{- if .Values.startupProbe.enabled }}
+          {{- if .Values.startupProbe.enabled}}
           startupProbe:
-            httpGet:
-              path: /api/v3/health/live
-              port: {{ .Values.service.portName | default "http"  }}
-            initialDelaySeconds: {{ default 0 .Values.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ default 10 .Values.startupProbe.periodSeconds }}
-            failureThreshold: {{ default 3 .Values.startupProbe.failureThreshold }}
-            successThreshold: {{ default 1 .Values.startupProbe.successThreshold }}
-            timeoutSeconds: {{ default 1 .Values.startupProbe.timeoutSeconds }}
+            {{- tpl (toYaml (omit .Values.startupProbe "enabled")) . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/yoma-api/templates/hpa.yaml
+++ b/helm/yoma-api/templates/hpa.yaml
@@ -10,7 +10,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "yoma-api.fullname" . }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  minReplicas: {{ .Values.replicaCount }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}

--- a/helm/yoma-api/templates/hpa.yaml
+++ b/helm/yoma-api/templates/hpa.yaml
@@ -3,8 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "yoma-api.fullname" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -29,4 +28,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/yoma-api/templates/ingress.yaml
+++ b/helm/yoma-api/templates/ingress.yaml
@@ -14,8 +14,7 @@ metadata:
   {{- with .namespace }}
   namespace: {{ tpl . $ }}
   {{- end }}
-  labels:
-    {{- include "yoma-api.labels" $ | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm/yoma-api/templates/pdb.yaml
+++ b/helm/yoma-api/templates/pdb.yaml
@@ -3,15 +3,15 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "yoma-api.fullname" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 spec:
   {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- else }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels:
-      {{- include "yoma-api.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
 {{- end }}

--- a/helm/yoma-api/templates/post-install.yaml
+++ b/helm/yoma-api/templates/post-install.yaml
@@ -3,8 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "yoma-api.fullname" . }}-sqlserver-init
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -15,8 +14,8 @@ spec:
   template:
     metadata:
       name: {{ include "yoma-api.fullname" . }}
-      labels:
-        {{- include "yoma-api.labels" . | nindent 4 }}
+      {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.postInstallHook.initContainers }}

--- a/helm/yoma-api/templates/pvc.yaml
+++ b/helm/yoma-api/templates/pvc.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "yoma-api.fullname" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/helm/yoma-api/templates/secret.yaml
+++ b/helm/yoma-api/templates/secret.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "yoma-api.fullname" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 stringData:
   {{ .Values.appSettings.fileName }}: |-
     {{- tpl ( toPrettyJson .Values.appSettings ) . | nindent 4 }}

--- a/helm/yoma-api/templates/service.yaml
+++ b/helm/yoma-api/templates/service.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "yoma-api.fullname" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -17,5 +16,5 @@ spec:
       targetPort: {{ $v.targetPort | default $v.port }}
       protocol: TCP
     {{- end }}
-  selector:
-    {{- include "yoma-api.selectorLabels" . | nindent 4 }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/helm/yoma-api/templates/serviceaccount.yaml
+++ b/helm/yoma-api/templates/serviceaccount.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "yoma-api.serviceAccountName" . }}
-  labels:
-    {{- include "yoma-api.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -26,7 +26,7 @@ serviceAccount:
 podAnnotations:
   ad.datadoghq.com/yoma-api.logs: '[{ "service" : "yoma-api", "source" : "csharp"}]'
   # gcr.io/datadoghq/dd-lib-dotnet-init
-  admission.datadoghq.com/dotnet-lib.version: v2.56.0
+  admission.datadoghq.com/dotnet-lib.version: v2.57.0
 deploymentLabels:
   tags.datadoghq.com/service: yoma-api
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -34,6 +34,7 @@ podLabels:
   admission.datadoghq.com/enabled: "false" # disabled by default (for now)
   tags.datadoghq.com/service: yoma-api
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"
+commonLabels: {}
 
 env:
   DD_RUNTIME_METRICS_ENABLED: true
@@ -120,35 +121,31 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  behavior:
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#default-behavior
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 15
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 15
 
 nodeSelector: {}
 tolerations: []
-affinity:
-  nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        preference:
-          matchExpressions:
-            - key: node.kubernetes.io/lifecycle
-              operator: In
-              values:
-                - spot
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: '{{ include "yoma-api.name" . }}'
-              app.kubernetes.io/instance: "{{ .Release.Name }}"
-          topologyKey: kubernetes.io/hostname
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: '{{ include "yoma-api.name" . }}'
-              app.kubernetes.io/instance: "{{ .Release.Name }}"
-          topologyKey: kubernetes.io/zone
+affinity: {}
+podAffinityPreset: ""
+podAntiAffinityPreset: soft
+nodeAffinityPreset:
+  type: soft
+  key: node.kubernetes.io/lifecycle
+  values:
+    - spot
 
 volumeMounts: {}
 volumes: {}

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -179,16 +179,46 @@ postInstallHook:
         - name: init
           mountPath: /init
 
-readinessProbe:
-  enabled: true
 livenessProbe:
   enabled: true
+  # failureThreshold: 3
+  httpGet:
+    path: /api/v3/health/live
+    port: http
+  # initialDelaySeconds: 0
+  # periodSeconds: 10
+  # successThreshold: 1
+  # timeoutSeconds: 1
+readinessProbe:
+  enabled: true
+  # failureThreshold: 3
+  httpGet:
+    path: /api/v3/health/ready
+    port: http
+  # initialDelaySeconds: 0
+  # periodSeconds: 10
+  # successThreshold: 1
+  # timeoutSeconds: 1
 startupProbe:
   enabled: true
-  periodSeconds: 10
   failureThreshold: 30
+  httpGet:
+    path: /api/v3/health/live
+    port: http
+  # initialDelaySeconds: 0
+  periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 3
+
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - sleep 5
+    # sleep:
+    #   seconds: 5
 
 podDisruptionBudget:
   enabled: false


### PR DESCRIPTION
* Enable Horizontal Pod Autoscaling of Yoma API
  * If CPU usage exceeds 200% of the **_request_**, begin scaling pods
* Enable Pod Disruption Budgets for Yoma API to guarantee pod uptime
* Add a 5s sleep pre-stop lifecycle hook
* Use Bitnami pattern for health probes
* Add `bitnami/common` as a dependency to Yoma API
* Configure HPA Behavior
* Use Bitnami's Affinity templating
