### PR TITLE
Fix Husky Install Deprecated warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "postinstall": "husky install",
-    "test:cypress": "cypress open"
+    "test:cypress": "cypress open",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@types/cypress": "^1.1.3",


### PR DESCRIPTION
* Fix `install command is DEPRECATED` warning