### PR TITLE
Bump Helm dependencies

### DIFF
--- a/helm/keycloak/Chart.lock
+++ b/helm/keycloak/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.22.0
+  version: 2.23.0
 - name: keycloakx
   repository: https://codecentric.github.io/helm-charts
   version: 2.2.2
 - name: keycloak-config-cli
   repository: git+https://github.com/didx-xyz/keycloak-config-cli@contrib/charts?ref=init-containers&sparse=0
   version: 5.8.1-SNAPSHOT
-digest: sha256:2ca0168754e5e4576697f30aec57c998a203324e375ef139eea37e5d3b4a474e
-generated: "2024-08-27T16:16:23.167974+02:00"
+digest: sha256:e1b377196467a5fba185d1141331771826a4fc15b3b3f8bad3ca8d22327ee971
+generated: "2024-09-17T13:54:36.502824+02:00"

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -328,7 +328,7 @@ keycloak:
     admission.datadoghq.com/enabled: "false" # disabled by default (for now)
   podAnnotations:
     # gcr.io/datadoghq/dd-lib-java-init
-    admission.datadoghq.com/java-lib.version: v1.38.1
+    admission.datadoghq.com/java-lib.version: v1.39.0
     ad.datadoghq.com/keycloak.logs: '[{ "service": "keycloak", "source": "jboss_wildfly" }]'
 
   lifecycleHooks: |

--- a/helm/yoma-api/Chart.lock
+++ b/helm/yoma-api/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.22.0
-digest: sha256:e66b153d2c35ef24ff65f0e17b63643843360e98a69ddfcd99b38befe00e6c37
-generated: "2024-08-27T15:13:37.79633+02:00"
+  version: 2.23.0
+digest: sha256:6f8a5c162a291f6586c3eff9e6c0d3ba789bf1fe356681c300c1169303e29bcf
+generated: "2024-09-17T13:54:26.85592+02:00"

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -26,7 +26,7 @@ serviceAccount:
 podAnnotations:
   ad.datadoghq.com/yoma-api.logs: '[{ "service" : "yoma-api", "source" : "csharp"}]'
   # gcr.io/datadoghq/dd-lib-dotnet-init
-  admission.datadoghq.com/dotnet-lib.version: v2.57.0
+  admission.datadoghq.com/dotnet-lib.version: v3.3.0
 deploymentLabels:
   tags.datadoghq.com/service: yoma-api
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/helm/yoma-web/values.yaml
+++ b/helm/yoma-web/values.yaml
@@ -25,7 +25,7 @@ serviceAccount:
 
 podAnnotations:
   # gcr.io/datadoghq/dd-lib-js-init
-  admission.datadoghq.com/js-lib.version: v5.19.0
+  admission.datadoghq.com/js-lib.version: v5.22.0
 deploymentLabels:
   tags.datadoghq.com/service: yoma-web
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
* Bump `bitnami/common` `2.22.0` -> `2.23.0`
* Bump Datadog Java Lib `1.38.1` -> `1.39.0`
* Bump Datadog Dotnet Lib `2.57.0` -> `3.3.0`
* Bump Datadog JS Lib `5.19.0` -> `5.22.0`