### PR TITLE
Added flags for condition and link evaluation in rule processing

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/Marketplace/Models/StoreAccessControlRuleEvaluationItemReason.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Marketplace/Models/StoreAccessControlRuleEvaluationItemReason.cs
@@ -2,6 +2,8 @@ namespace Yoma.Core.Domain.Marketplace.Models
 {
   public class StoreAccessControlRuleEvaluationItemReason
   {
+    public bool ConditionPassed { get; set; }
+
     public string Reason { get; set; }
 
     public List<StoreAccessControlRuleEvaluationItemReasonLink>? Links { get; set; }

--- a/src/api/src/domain/Yoma.Core.Domain/Marketplace/Models/StoreAccessControlRuleEvaluationItemReasonLink.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Marketplace/Models/StoreAccessControlRuleEvaluationItemReasonLink.cs
@@ -2,6 +2,8 @@ namespace Yoma.Core.Domain.Marketplace.Models
 {
   public class StoreAccessControlRuleEvaluationItemReasonLink
   {
+    public bool RequirementMet { get; set; }
+
     public string Title { get; set; }
 
     public string URL { get; set; }


### PR DESCRIPTION
- Implemented `ConditionPassed` to report if a rule's condition (age, gender, opportunities) was satisfied.
- Introduced `RequirementMet` in opportunity links to indicate whether the user completed each opportunity.