### PR TITLE
[YOMA-528, YOMA-482] Access Rules and SA Youth bug fixes

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/Marketplace/Services/StoreAccessControlRuleService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Marketplace/Services/StoreAccessControlRuleService.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System.Transactions;
 using Yoma.Core.Domain.Core;
 using Yoma.Core.Domain.Core.Exceptions;
+using Yoma.Core.Domain.Core.Extensions;
 using Yoma.Core.Domain.Core.Helpers;
 using Yoma.Core.Domain.Core.Interfaces;
 using Yoma.Core.Domain.Core.Models;
@@ -531,9 +532,9 @@ namespace Yoma.Core.Domain.Marketplace.Services
 
           var opportunityLinks = rule.Opportunities.Select(o => new StoreAccessControlRuleEvaluationItemReasonLink
           {
-            Title = o.Title,
+            Title = o.Title.RemoveSpecialCharacters(),
             URL = o.YomaInfoURL(_appSettings.AppBaseURL),
-            RequirementMet = myOpportunitiesCompleted?.Any(i => i.Id == o.Id) == true // check if user completed the opportunity
+            RequirementMet = myOpportunitiesCompleted?.Any(i => i.OpportunityId == o.Id) == true // check if user completed the opportunity
           }).ToList();
 
           if (rule.OpportunityOption == null)
@@ -541,8 +542,8 @@ namespace Yoma.Core.Domain.Marketplace.Services
 
           var conditionPassed = rule.OpportunityOption.Value switch
           {
-            StoreAccessControlRuleOpportunityCondition.All => rule.Opportunities.All(o => myOpportunitiesCompleted?.Any(i => i.Id == o.Id) == true),
-            StoreAccessControlRuleOpportunityCondition.Any => rule.Opportunities.Any(o => myOpportunitiesCompleted?.Any(i => i.Id == o.Id) == true),
+            StoreAccessControlRuleOpportunityCondition.All => rule.Opportunities.All(o => myOpportunitiesCompleted?.Any(i => i.OpportunityId == o.Id) == true),
+            StoreAccessControlRuleOpportunityCondition.Any => rule.Opportunities.Any(o => myOpportunitiesCompleted?.Any(i => i.OpportunityId == o.Id) == true),
             _ => throw new InvalidOperationException($"Opportunity option '{rule.OpportunityOption}' not supported")
           };
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.SAYouth/Client/SAYouthClient.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.SAYouth/Client/SAYouthClient.cs
@@ -187,9 +187,10 @@ namespace Yoma.Core.Infrastructure.SAYouth.Client
         SponsoringPartner = request.OrganizationYoma.Name.RemoveSpecialCharacters().TrimToLength(200),
         Title = request.Opportunity.Title.RemoveSpecialCharacters().TrimToLength(200),
         Description = request.Opportunity.Description,
+        // ensure 'HasCertification' of type 'NonAccreditedCertification' when 'VerificationEnabled'; Yoma's certification is not accredited 
         HasCertification = request.Opportunity.VerificationEnabled ? YesNoOption.Yes : YesNoOption.No,
-        CertificationType = request.Opportunity.VerificationEnabled ? CertificateType.AccreditedCertification.ToString() : null,
-        CertificationDescription = request.Opportunity.Summary,
+        CertificationType = request.Opportunity.VerificationEnabled ? CertificateType.NonAccreditedCertification.ToString() : null,
+        CertificationDescription = request.Opportunity.VerificationEnabled ? request.Opportunity.Summary : null,
         CloseDate = request.Opportunity.DateEnd,
         Duration = request.Opportunity.ToDuration(),
         Requirements = "Instructions can be found in the description",


### PR DESCRIPTION
- SA Youth: ensure 'HasCertification' of type 'NonAccreditedCertification' when 'VerificationEnabled'; Yoma's certification is not accredited
- Access Rules: Fixed issue with completed opportunity comparisons