### PR TITLE
YOMA-538: Configure Twilio Keycloak SMS Provider

### DIFF
--- a/helm/keycloak/conf/dev/secrets.yaml
+++ b/helm/keycloak/conf/dev/secrets.yaml
@@ -29,6 +29,12 @@ keycloak:
                 database: ENC[AES256_GCM,data:E0jLFFQazWU=,iv:svmiHaLI96ty8NLaLt6Ymj0dKdnUHOGeERqHLPckxdk=,tag:sUHlYtuTURA3Uji3MtboWQ==,type:str]
                 user: ENC[AES256_GCM,data:WgSbrgPm0I4=,iv:+zNxjybnPaEc8hqz/8KiAgFnTqjy4YfBeD2FRyEMuyg=,tag:BQhC/umkzAzh8BC6/F2WBQ==,type:str]
                 password: ENC[AES256_GCM,data:p6jOnvclPDA=,iv:5/4OGvNaEl/tsiKRItUZC1L2LnIAhuentEvtf/jZwss=,tag:7yd/4poPZiZZaK/Kwe9QVg==,type:str]
+        twilio:
+            stringData:
+                sid: ENC[AES256_GCM,data:L79Y0WjRdp/XgezZ3g0hOwd37F1cA99XCf5mf3g7UZ/cHA==,iv:NblAErNdx1atd0VA37c+R0Filt9qM0f9aqs+zIK+Sig=,tag:fXhn1Eu6U4PBRD0ChY33Bw==,type:str]
+                token: ENC[AES256_GCM,data:paMQlGEXZR1lQZrOMvlLeZD5jCBpPNX84Qbd0uV6nSc=,iv:0R5JOt1DDB733eTHmyIrvk+sfn3KPdX/tRFLVuXKeQg=,tag:i8RKt2HPaH23gjfcmpUA9w==,type:str]
+                #ENC[AES256_GCM,data:XsKBXUjiDlQZdjNq5CZEzkmcbKi8,iv:pN3BlH/RF5/f3WrWuUACXh8ImqjJHIOFCLqHvl49lPQ=,tag:18cg58JpDHfue6Ys3LSpoQ==,type:comment]
+                number: ENC[AES256_GCM,data:Njxg8VZmjNRW3Mzy,iv:Lr5Qz6w4+p1Jv8SUE+cusmUn0zVxHI65I/HnuaQgDbQ=,tag:pVCrVkgO0NkelHdMVw7DJw==,type:str]
 config-cli:
     secrets:
         KEYCLOAK_USER: ENC[AES256_GCM,data:DQzrhhayQ2Q=,iv:NwgCJZuKx+D2gUcSc1T+Vv0LigPo8UFeiYgbBfvT0vM=,tag:arBptodK9nGgPVRqsk7zGQ==,type:str]
@@ -54,8 +60,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-29T07:21:28Z"
-    mac: ENC[AES256_GCM,data:f0IgtC3m48QjEfaxx23ZS6YFOkcCmhrCFZr4msYfltQ3k6qbk6Qbe7GvJLnWpHETB5+B6OjRVfPciC6p1Y3C4Juf+Xa++5PUPf9D5PxAKcNI/SL8LKhejgmARlE2JfbfYd7bWNJZvYJy6CGR+jlgE4RnxuU7XbYgKABxjMhF/A0=,iv:XF+41nyyJpG/y8vgU4xw3TUWsS1ABCnIZnBSbssIyPo=,tag:ZMyqGPn2MKRicykri5hKkQ==,type:str]
+    lastmodified: "2024-10-14T10:18:19Z"
+    mac: ENC[AES256_GCM,data:7MOVA7BxxiJ5B/aH01etq3AuCxmswnxzpDyQUltPXmx4hMzBgwiuXP+hDg1Xuu99PNKy2Zq9Up5Ttv9HAzr79gV2WtYJopV0UP+enedNfeJTmj4lFoehkU1eralWyrpDlDH6tiJfZ8B8JOUPvMJLMz438Dh+BdK2mMmUCGzG+hA=,iv:8xOA+pG2PxKIU/MWGWk7UNgyGrO7Dmnt19V3NXNR7/g=,tag:k0cEO/iyeEXX+sLtULy5Hg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.0
+    version: 3.9.1

--- a/helm/keycloak/conf/prod/secrets.yaml
+++ b/helm/keycloak/conf/prod/secrets.yaml
@@ -8,6 +8,12 @@ keycloak:
                 #ENC[AES256_GCM,data:lltrqHjMjrp+ZaGwOXM=,iv:kTnOAn3acFbMjFUE1nZNigomN3LrtOx0U2n1SFwlBeg=,tag:YdbwJyOLZV7ws5JDvhzJWg==,type:comment]
                 #ENC[AES256_GCM,data:VvwA2+9/yCyjQNc1JFM96yUxJr/orj07vnGjUY/hL3JB7saF7H6GSpBI,iv:4Xxc8MPEVT8SdFQSpfBBxPPoCCRGGQTdb8nw65+xnJ8=,tag:gLS1vBprSHHkTpkow6PjZA==,type:comment]
                 #ENC[AES256_GCM,data:o8X/VsS2vcLN6OoG5Q02lJNjTL6GSBgVq5W8/znbImHez42a0IqPpLBnPna+Dq6Ij9LTzAF3mYYfsnXbLfKcRpxj,iv:PXb3RXOC3/9JfqoNqUTyukReRhu6cE7glEojY/cH6B4=,tag:QvPLh2JFJ7515FbUuzL6Wg==,type:comment]
+    twilio:
+        stringData:
+            sid: ENC[AES256_GCM,data:N0M1bMHJtRS3CcHOiOB1MMFbk7bZHdM4HE4imYCXxHe1MQ==,iv:J3sMhIu1gxQClMakplqMTYxlTzH4a5KtMWdK4WqLdHs=,tag:GkDbZAs4enbs2MVzZDFy4g==,type:str]
+            token: ENC[AES256_GCM,data:IbnlvLumyhD3x+H5LU5sxBdLDllqtfa6+rDZpvUywYo=,iv:0TNBXYs3DeyuSbgI4R11Ak9ciWJd2Q8TEIxXrcQy0YE=,tag:RyX16zac9qL6uhTZt94R3w==,type:str]
+            #ENC[AES256_GCM,data:/r0Q15phJVHt6oQMz8fGHjD5TQ9INRGqbfOjN36gIA==,iv:uOm8dT4fNji69McgpBDfWHSt3FhfiJvPlv2dwgBsR3c=,tag:pkBMc1TVfDBGil/fsOv0Vg==,type:comment]
+            number: ENC[AES256_GCM,data:KDiVNPKYL5cqOns=,iv:cQiCo1p6KpU5TzBUu0kvyVrHtgNdCSIC75MXGJBtSJA=,tag:ddh3y+nvlbHnMW7TjPlk8A==,type:str]
 config-cli:
     secrets:
         KEYCLOAK_USER: ENC[AES256_GCM,data:k/b9R1DS3lw=,iv:n4OGjLPXpPoyrxCtCz+BPmwwy+fDcD6aG1J1whUzuXw=,tag:Pd+vak3/ZukMe3fcRqHFpg==,type:str]
@@ -33,8 +39,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-29T07:21:52Z"
-    mac: ENC[AES256_GCM,data:V1e0QvQl4prFG7UXaQST2Oz/lzPOMk3Udr36pVsHK3lj9OXl1V4SuMzAWyLJjaMTBprDvkjh2xk5tkYjYwj6/6H/GnawHLdAdjpNQk4zd1v0iWP1KfngAOhNN4tDDuXekK5e5WrHUBoDvRyunXK2zgd27Im2IqtFczwgmZ/6mr8=,iv:jwh32O52eHk+DL9otJPxncTSgjG2fEoMA52QlvKzl3k=,tag:tbzXPsbGFWnZKfsOaCJBUQ==,type:str]
+    lastmodified: "2024-10-14T10:14:37Z"
+    mac: ENC[AES256_GCM,data:1lVuCQAomxtW+E8zSutRekucH9sAUJ1Fs+yTZya3xVlcPMCXPb3g5jQgMa9ajagGAriPs63x2EKjALrLZWCnyyQBtn48NJHO5pJkquq05tiqeCCVuArs9ZGMWDzewZkIqghWyj55+gkZbP/tdXjFK0hSYgIKm0T3J14gdPqxsds=,iv:Dnf9fXLpc6+KH0xyOne+o/ePJ+t7pWSVSt0wihKO+8o=,tag:K1Rzkl8YEJckbbwe5soG5Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.0
+    version: 3.9.1

--- a/helm/keycloak/conf/stage/secrets.yaml
+++ b/helm/keycloak/conf/stage/secrets.yaml
@@ -4,10 +4,12 @@ keycloak:
             stringData:
                 WEBHOOK_HTTP_AUTH_USERNAME: ENC[AES256_GCM,data:kdNoR0TG3g==,iv:SyrnoQetML1TaQ3Q0gx0qaw2twLaqByfCXC8p5h3/ac=,tag:bUTJWQ0VrGwySlaiyCHE9Q==,type:str]
                 WEBHOOK_HTTP_AUTH_PASSWORD: ENC[AES256_GCM,data:OgP8nv4ob23E3btlwoTlFj+2ckJW5zU67RMX9lp4RLA=,iv:s2HqvlhzqGleTOJbC1z6oyzWiz6S5zu62zNx11y8Mic=,tag:U+Z8WCFhDrXrn2qqU0lQSA==,type:str]
-                #ENC[AES256_GCM,data:KthHAuqqxw==,iv:FlWBiukpHGyEBoJNNCKG/F3kMqi5mYwuRLPFfF9BUAk=,tag:2nHj2HoNX6ZrBI+Bbayldg==,type:comment]
-#ENC[AES256_GCM,data:dZSqAcdfG1b3IhPYhAMtXZPbtizE+rQCyNt/bSeaOX/qY5ScBQqoxuHL4qtFlGZtGmiZtqvwMqEhUTc5fegaZ6ep83Z/HdJObRPtjmEAg42ORRPWOVaVmm9bI2nNh0MCwr8tjbvg2O5I1aqrETzJFo9zkZxvpmrhMd/mHJHHipJkBxs=,iv:q2u9QupkWkDEcw64qKr+5FHtdm56lBe6pSCw4f2r/A8=,tag:1atRQX1bp+/OcgkSHFK5fg==,type:comment]
-#ENC[AES256_GCM,data:l+wobjYxdlJKFqISuazpFUNNlqaZ2zpjVnK3tFOX+l6FzDmh0MzXM6efypMdgRKXgR5XQaiXwlLgRLbtP8wxdZGnouVHH4F5uZwtg51NwvsbNiJ2iWU4Bf1OiAsaoeF+oyLinwjnQ8Xa2t48fbC8ZNWPqDlSTJ/dtcotBK+YcCfJZtFCrGxoROQXuwWp23obcp1HFLySGgKMrzr1anF3S1pvXJL/ik8=,iv:jJdJb3Bp/HKabP0LK1OYk6eQ7BMY1QYEx8vISvPKSZI=,tag:5p/lsUlBtqrda15LqjrhBA==,type:comment]
-#ENC[AES256_GCM,data:tgOPq8BYWbSfNmyGejxhHaWiXVC6PZtoSN5k+0m015xh+0lWSSzqmJ67PhAzyDVDV+iHehe1IvCIsQ216FdHwpu05jsS1L1OeMtzaqSjYaIZvOPj5WY1dwzcsTRIH7tAGwxMCZW/JH+Ch6XE7UgYwnMSEmiH4qyZHoe+bctXu7sPfLZ/zP5ES6ZazDrKNVU5tutHqXZn2FlI7ezYaLTHlP0GlbG5EeJfZaMv,iv:rdlmfW6ppeYSgjraea3KUdOzQF9nooRedWUnjlAm/u0=,tag:CW8jwOt34izyVt9kX1dymg==,type:comment]
+        twilio:
+            stringData:
+                sid: ENC[AES256_GCM,data:CQHYN0RGNZhs592q7mzaVeGD2LHSrL9VrIALO2vdgAY3mg==,iv:P8BM620udzO+8zA16fsxy7NOp9p/44TaiLxaE7htsoA=,tag:06czsr6g+xSHWDZAJ7py7g==,type:str]
+                token: ENC[AES256_GCM,data:irwkx/6cx0SsWI3b0WDu0/3XapWXLPvkP5RHjHLTlwU=,iv:Hv9E/peJtxAK+o/56Rho1f4agtGQy+ZDIKqbrS80UM0=,tag:OF1vtOffdmQGxYpX60fIwg==,type:str]
+                #ENC[AES256_GCM,data:0M8tnl4QDFSMvMeqJFY7gATiw4Wh4FaGbhL2OPDU1A==,iv:K46YhQT+I7wCAV0pwJcBc+ipLfW37t0S788ZMRIOrwg=,tag:E5yc1wVvcFmX4QSD+DSFHQ==,type:comment]
+                number: ENC[AES256_GCM,data:JoeaB8FUpM9hdZw=,iv:PhkaxdcaDLFBJ+2QSMqcRAW0+i7kKFlLPAAfTj/hEhQ=,tag:So2vlxr/QrKhTcv97AhAPw==,type:str]
 config-cli:
     secrets:
         KEYCLOAK_USER: ENC[AES256_GCM,data:eXMN0g6tu3I=,iv:+VFQ4+ug/ux/QKq8GQ4MgPMf/3sqlpgZPAOw3F6qZjg=,tag:AExr/1YRiWwaTRIFZzzdAA==,type:str]
@@ -33,8 +35,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-29T07:22:03Z"
-    mac: ENC[AES256_GCM,data:VzQ9L9QcGWQkPVIEIVGtqJ4FdQroAV8TUs1cX9dFL0FiCKF8fhnj0yEMhY46uQqhGMpl6ljDPJniLQA8rhQPsLE/qk7n2pDN6jQpvbYN+dvDv9sHkmK+JKPJf4P0PyTz3/ufvMbfKPvInA4l5rOL7NrQTkKu/R1bc7dYV67vKtY=,iv:pk85jVmdI5Tg6kV8ZdhRkeJ2bFMC9yCuT2zsF+pIi0g=,tag:mAkeu1+IlkvO34toSF9w+w==,type:str]
+    lastmodified: "2024-10-14T10:14:51Z"
+    mac: ENC[AES256_GCM,data:MtIEhZ1/EkMfYuWtcH7jGHDt8FXUbOXLqqW7a/you4DX6u7tvyWGymqs6NehU+FmqMxkO/NrYknWvHcs4TCZyjEWg+QSwo2MXqmWWXVA7TV1DmPMeZTsQYXzt8qQPFUUOo8v2igQa1/H9LbsGzZq0Tp0vU4FV4MPBAF95CNsO+U=,iv:ztamzl7DzXdnn9pyK8i5ZbdiXx5pVbNjryDCf95PKDs=,tag:3Pd+KtlqyANhz2KMoW+Y4w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.0
+    version: 3.9.1

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -197,7 +197,7 @@ keycloak:
     enabled: false
     ref: develop
   extraInitContainers: |-
-    - name: download-extensions
+    - name: download-providers
       image: docker.io/busybox:stable
       imagePullPolicy: IfNotPresent
       command:
@@ -205,9 +205,16 @@ keycloak:
       args:
         - -c
         - |-
+          cd /providers
           wget -q \
             https://github.com/vymalo/keycloak-webhook/releases/download/v{{ .Values.webhook.version }}/keycloak-webhook-{{ .Values.webhook.version }}-all.jar \
               -O /providers/keycloak-webhook-{{ .Values.webhook.version }}.jar
+          wget -qO - \
+            --header="Accept:application/vnd.github.v3.raw" \
+            https://api.github.com/repos/didx-xyz/yoma/tarball/{{ .Values.postInstallHook.ref }} | tar xz
+          cp -v ./didx-xyz-yoma-*/src/keycloak/providers/jars/*.jar /providers
+          rm -rf ./didx-xyz-yoma-*
+          chown -R 1000:1000 /providers
       volumeMounts:
         - name: providers
           mountPath: /providers
@@ -281,6 +288,27 @@ keycloak:
       value: sslmode=prefer
     - name: KC_LOG_CONSOLE_OUTPUT
       value: json
+    - name: KC_SPI_PHONE_DEFAULT_SERVICE
+      value: twilio
+    - name: KC_SPI_SENDER_SERVICE_TWILIO_SID
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "keycloak.fullname" . }}-twilio
+          key: sid
+    - name: KC_SPI_SENDER_SERVICE_TWILIO_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "keycloak.fullname" . }}-twilio
+          key: token
+    - name: KC_SPI_SENDER_SERVICE_TWILIO_NUMBER
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "keycloak.fullname" . }}-twilio
+          key: number
+    - name: KC_SPI_PHONE_DEFAULT_TOKEN_EXPIRES_IN
+      value: "120"
+    - name: KC_SPI_PHONE_DEFAULT_YOMA_DEFAULT_NUMBER_REGEX
+      value: "^\\+?\\d+$"
 
   affinity: |-
     nodeAffinity:
@@ -328,7 +356,7 @@ keycloak:
     admission.datadoghq.com/enabled: "false" # disabled by default (for now)
   podAnnotations:
     # gcr.io/datadoghq/dd-lib-java-init
-    admission.datadoghq.com/java-lib.version: v1.39.0
+    admission.datadoghq.com/java-lib.version: v1.40.1
     ad.datadoghq.com/keycloak.logs: '[{ "service": "keycloak", "source": "jboss_wildfly" }]'
 
   lifecycleHooks: |
@@ -378,6 +406,13 @@ keycloak:
 
   http:
     relativePath: /auth
+
+  secrets:
+    twilio:
+      stringData:
+        sid: superDuperVerySecret
+        token: superDuperVerySecret
+        number: superDuperVerySecret
 
   autoscaling:
     # If `true`, an autoscaling/v2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.23 or above)

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -102,20 +102,21 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: password
       KC_LOG_LEVEL: INFO
+      # Custom providers
+      KC_SPI_PHONE_DEFAULT_SERVICE: dummy
+      # KC_SPI_PHONE_DEFAULT_SERVICE: twilio
+      # KC_SPI_SENDER_SERVICE_TWILIO_SID: your_account_sid
+      # KC_SPI_SENDER_SERVICE_TWILIO_TOKEN: your_auth_token
+      # KC_SPI_SENDER_SERVICE_TWILIO_NUMBER: your_number
+      KC_SPI_PHONE_DEFAULT_TOKEN_EXPIRES_IN: 120 # sms expires, 120 seconds
+      # Notice: will match after canonicalize number. eg: INTERNATIONAL: +41 44 668 18 00 , NATIONAL: 044 668 18 00 , E164: +41446681800
+      KC_SPI_PHONE_DEFAULT_YOMA_DEFAULT_NUMBER_REGEX: ^\\+?\\d+$
     ports:
       - 0.0.0.0:8080:8080
     command:
-      - "start-dev"
-      - "--db=postgres"
-      - "--features=declarative-user-profile"
-      # custom providers
-      - "--spi-phone-default-service=dummy"
-      # - "--spi-phone-default-service=twilio" # Twilio sms provider
-      # - "--spi-message-sender-service-twilio-account=your_account_sid"
-      # - "--spi-message-sender-service-twilio-token=your_auth_token"
-      # - "--spi-message-sender-service-twilio-number=your_number"
-      - "--spi-phone-default-token-expires-in=120" # sms expires, 120 seconds
-      - "--spi-phone-default-yoma-default-number-regex=^\\+?\\d+$" #Notice: will match after canonicalize number. eg: INTERNATIONAL: +41 44 668 18 00 , NATIONAL: 044 668 18 00 , E164: +41446681800
+      - start-dev
+      - --db=postgres
+      - --features=declarative-user-profile
     depends_on:
       keycloak-init:
         condition: service_completed_successfully


### PR DESCRIPTION
* Using the Twilio Test keys in Dev and Stage
* Using Twilio Test number in Dev
* Stage and Prod have a placeholder while we wait for the actual Yoma number
* Twilio Live credentials in Prod
* Download our custom Twilio Provider JARs in the Download Providers init container