### PR TITLE
Hotfix: Keycloak Memory Req/Limits

### DIFF
--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -38,10 +38,10 @@ keycloak:
   resources:
     requests:
       cpu: 250m
-      memory: 2Gi
+      memory: 2048Mi
     limits:
       cpu: 4000m
-      memory: 2Gi
+      memory: 2048Mi
 
   themes:
     enabled: true


### PR DESCRIPTION
* Must be in `Mi` not `Gi`