### PR TITLE
Assign default 'User' role to users created via B2B endpoint

### DIFF
--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Keycloak/Client/KeycloakClient.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Keycloak/Client/KeycloakClient.cs
@@ -207,6 +207,9 @@ namespace Yoma.Core.Infrastructure.Keycloak.Client
 
         await userApi.PutUsersResetPasswordByUserIdAsync(_keycloakAuthenticationOptions.Realm, result.Id.ToString(), credential);
 
+        //add newly registered user to the default "User" role
+        await EnsureRoles(result.Id, [Constants.Role_User]);
+
         // if email is provided, trigger email verification — email is unconfirmed by default
         if (_environmentProvider.Environment != Domain.Core.Environment.Local && !string.IsNullOrEmpty(request.Email))
           await userApi.PutUsersSendVerifyEmailByUserIdAsync(_keycloakAuthenticationOptions.Realm, result.Id.ToString()); // same result as PutUsersExecuteActionsEmailByIdAsync["VERIFY_EMAIL"]

--- a/src/keycloak/exports/02-yoma-profile.yaml
+++ b/src/keycloak/exports/02-yoma-profile.yaml
@@ -388,7 +388,6 @@ userProfile:
       required:
         roles:
           - user
-          - admin
         scopes: []
       permissions:
         edit:


### PR DESCRIPTION
Fix Keycloak user profile: 'terms_and_conditions' not required for admins but editable