### PR TITLE
Single Yoma API replica on fresh deployment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -413,10 +413,6 @@ jobs:
       HELMFILE_VERSION: v0.171.0
       HELM_VERSION: v3.17.3
       TAG: ${{ needs.docker-push.outputs.image_version }}
-      HELM_PLUGINS: >-
-        https://github.com/databus23/helm-diff,
-        https://github.com/jkroepke/helm-secrets,
-        https://github.com/aslafy-z/helm-git
 
     concurrency:
       group: ${{ github.workflow }}-deploy-${{ github.event_name == 'release' && 'prod' || (github.event_name == 'push' && github.event.repository.default_branch == github.ref_name) && 'stage' || 'dev' }}
@@ -485,7 +481,10 @@ jobs:
           helmfile-args: |
             destroy \
               --environment dev
-          helm-plugins: ${{ env.HELM_PLUGINS }}
+          helm-plugins: >-
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets,
+            https://github.com/aslafy-z/helm-git
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
       - name: Delete Pods and PVCs
@@ -503,7 +502,10 @@ jobs:
               --selector=app=redis
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: ${{ env.HELM_PLUGINS }}
+          helm-plugins: >-
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets,
+            https://github.com/aslafy-z/helm-git
       # Diff on PR draft, otherwise Apply
       - name: Helmfile Apply/Diff Keycloak
         if: (
@@ -522,7 +524,10 @@ jobs:
               --set postInstallHook.ref=${{ github.event_name == 'release' && github.ref_name || github.sha }}
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: ${{ env.HELM_PLUGINS }}
+          helm-plugins: >-
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets,
+            https://github.com/aslafy-z/helm-git
       # On fresh deployment we want single replica due to DB migrations
       - name: Helmfile Apply Fresh API
         if: github.event.inputs.reset-deployments == 'true'
@@ -536,7 +541,10 @@ jobs:
               --set replicaCount=1
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: ${{ env.HELM_PLUGINS }}
+          helm-plugins: >-
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets,
+            https://github.com/aslafy-z/helm-git
       - name: Helmfile Apply/Diff API
         if: (
           github.event_name == 'release' ||
@@ -552,7 +560,10 @@ jobs:
               --set postInstallHook.ref=${{ github.event_name == 'release' && github.ref_name || github.sha }}
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: ${{ env.HELM_PLUGINS }}
+          helm-plugins: >-
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets,
+            https://github.com/aslafy-z/helm-git
       - name: Trigger Vercel Production Deployment
         if: github.event_name == 'release'
         run: |
@@ -572,4 +583,7 @@ jobs:
               --selector app=yoma-web
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: ${{ env.HELM_PLUGINS }}
+          helm-plugins: >-
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets,
+            https://github.com/aslafy-z/helm-git

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -232,8 +232,6 @@ jobs:
           else
             echo run=false >> $GITHUB_OUTPUT
           fi
-      - uses: docker/setup-qemu-action@v3
-        if: steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
       - uses: docker/setup-buildx-action@v3
         if: steps.should-run.outputs.run == 'true'
         with:
@@ -415,6 +413,10 @@ jobs:
       HELMFILE_VERSION: v0.171.0
       HELM_VERSION: v3.17.3
       TAG: ${{ needs.docker-push.outputs.image_version }}
+      HELM_PLUGINS: >-
+        https://github.com/databus23/helm-diff,
+        https://github.com/jkroepke/helm-secrets,
+        https://github.com/aslafy-z/helm-git
 
     concurrency:
       group: ${{ github.workflow }}-deploy-${{ github.event_name == 'release' && 'prod' || (github.event_name == 'push' && github.event.repository.default_branch == github.ref_name) && 'stage' || 'dev' }}
@@ -483,10 +485,7 @@ jobs:
           helmfile-args: |
             destroy \
               --environment dev
-          helm-plugins: |
-            https://github.com/databus23/helm-diff,
-            https://github.com/jkroepke/helm-secrets,
-            https://github.com/aslafy-z/helm-git
+          helm-plugins: ${{ env.HELM_PLUGINS }}
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
       - name: Delete Pods and PVCs
@@ -504,10 +503,7 @@ jobs:
               --selector=app=redis
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: |
-            https://github.com/databus23/helm-diff,
-            https://github.com/jkroepke/helm-secrets,
-            https://github.com/aslafy-z/helm-git
+          helm-plugins: ${{ env.HELM_PLUGINS }}
       # Diff on PR draft, otherwise Apply
       - name: Helmfile Apply/Diff Keycloak
         if: (
@@ -526,10 +522,21 @@ jobs:
               --set postInstallHook.ref=${{ github.event_name == 'release' && github.ref_name || github.sha }}
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: |
-            https://github.com/databus23/helm-diff,
-            https://github.com/jkroepke/helm-secrets,
-            https://github.com/aslafy-z/helm-git
+          helm-plugins: ${{ env.HELM_PLUGINS }}
+      # On fresh deployment we want single replica due to DB migrations
+      - name: Helmfile Apply Fresh API
+        if: github.event.inputs.reset-deployments == 'true'
+        uses: helmfile/helmfile-action@v2
+        with:
+          helmfile-args: |
+            apply \
+              --environment dev \
+              --selector app=yoma-api \
+              --set postInstallHook.ref=${{ github.sha }} \
+              --set replicaCount=1
+          helmfile-version: ${{ env.HELMFILE_VERSION }}
+          helm-version: ${{ env.HELM_VERSION }}
+          helm-plugins: ${{ env.HELM_PLUGINS }}
       - name: Helmfile Apply/Diff API
         if: (
           github.event_name == 'release' ||
@@ -545,10 +552,7 @@ jobs:
               --set postInstallHook.ref=${{ github.event_name == 'release' && github.ref_name || github.sha }}
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: |
-            https://github.com/databus23/helm-diff,
-            https://github.com/jkroepke/helm-secrets,
-            https://github.com/aslafy-z/helm-git
+          helm-plugins: ${{ env.HELM_PLUGINS }}
       - name: Trigger Vercel Production Deployment
         if: github.event_name == 'release'
         run: |
@@ -568,7 +572,4 @@ jobs:
               --selector app=yoma-web
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
-          helm-plugins: |
-            https://github.com/databus23/helm-diff,
-            https://github.com/jkroepke/helm-secrets,
-            https://github.com/aslafy-z/helm-git
+          helm-plugins: ${{ env.HELM_PLUGINS }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -499,7 +499,7 @@ jobs:
               --environment dev \
               --selector=app=postgresql-keycloak \
               --selector=app=postgresql \
-              --selector=app=redis
+              --selector=app=valkey
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helm-version: ${{ env.HELM_VERSION }}
           helm-plugins: >-

--- a/helm/keycloak/conf/dev/secrets.yaml
+++ b/helm/keycloak/conf/dev/secrets.yaml
@@ -24,7 +24,7 @@ keycloak:
                 yoma-system-user-password: ENC[AES256_GCM,data:+cg9EgaPgGc/rg==,iv:NFGrC4pUPNW5G+9avOOFmUHxv3v8dIDYfR0fwavXDRs=,tag:HvwwEav61IEp/q04TQ8WDg==,type:str]
         db:
             stringData:
-                host: ENC[AES256_GCM,data:x4MpSD9RX3MEluSwCnwuMWwj1g==,iv:RiCWxs+x6PWcXUzFgr5lQq0idQGmaDva3qwO8TfyN5Q=,tag:2qqH+9a5IsdSsLhz2GguHg==,type:str]
+                host: ENC[AES256_GCM,data:VqNQ1x/rlGqUSq4GITfQvJI=,iv:17CrN8Ezn2vXf6suNseUEAUxpj/botMTKYwKnapZZBY=,tag:wo4kXHV6NXM/fzOJhSqMTg==,type:str]
                 port: ENC[AES256_GCM,data:BYxrhg==,iv:67NcBKqsZX67eSnymseKXm4TR43uT/9dRSUxIl0U8aI=,tag:lB5XAtKHXoYE6zw4abS7UA==,type:str]
                 database: ENC[AES256_GCM,data:E0jLFFQazWU=,iv:svmiHaLI96ty8NLaLt6Ymj0dKdnUHOGeERqHLPckxdk=,tag:sUHlYtuTURA3Uji3MtboWQ==,type:str]
                 user: ENC[AES256_GCM,data:WgSbrgPm0I4=,iv:+zNxjybnPaEc8hqz/8KiAgFnTqjy4YfBeD2FRyEMuyg=,tag:BQhC/umkzAzh8BC6/F2WBQ==,type:str]
@@ -62,7 +62,7 @@ sops:
           created_at: "2023-07-27T08:52:40Z"
           enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
           aws_profile: ""
-    lastmodified: "2025-04-16T12:39:17Z"
-    mac: ENC[AES256_GCM,data:/JeRv78FF0CXCVO526S1H5Ja+RCOEeYkw0SDv+sriTGjFppFDwf2EE4VhZitfr9TB3UTX8ViJj5t5EwXRhsyNGovskb3ldf89dkbKYIMYybXBGgtB7ErfLcukJKGgbbsx+lK68YFgeRfy+gXCjFBeR+TwDc692LtqmsTD2Vm4GY=,iv:ektevrRpba6Lp4djsT7pSOes9KB95WKwfeIChqYhPnA=,tag:MaQzpwQNgWQbkO+XxrepyQ==,type:str]
+    lastmodified: "2025-04-17T10:22:07Z"
+    mac: ENC[AES256_GCM,data:J8maX/k1PtbtvLwuEViZrKE+z0wX0QHhS4UpN5wI5pabhcPJJZ28TXqOhuzlwdxk2xWmD0BbsuwmZ4U4G16rpbzl3K9HomCuD9Vn4WCWboTKnpgVpW/1m2sxO7i9BrTWOQtbvzpuT2vKqLkFAuqCWDEY6il+AqVqI9KSghNeoBs=,iv:zNXw3c7JTMmUGgLF0ycQ4Q43494f3ldYJzUTas/Hbb8=,tag:zV2bCMIBhn5kbSx40CevHg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/helm/yoma-api/conf/base/secrets.yaml
+++ b/helm/yoma-api/conf/base/secrets.yaml
@@ -21,7 +21,7 @@ appSettings:
     AllowedOrigins: ENC[AES256_GCM,data:3EzQmn3zNNWYSMMBtVIZ097R1LaH9aiArL9M4NYjWwl0OMSFpAV6Dx2VDIx21Of8HNeuR4D6QS3z8x4EW/soHSY=,iv:iJ+briy0QcbjKaa1fc0bGmbvXOJah4OfvJfSyXUoSro=,tag:l2zLM/ZVFsqiEAQ7nEv5hg==,type:str]
     ConnectionStrings:
         SQLConnection: ENC[AES256_GCM,data:YEYF6r29jaUX7AYQbTwMtqGUNp7vVVjnwbZa3pzAvsPMh4VltCEz3ZwnkkXIzkrYZYxEBexuS6PV9rl7oTq3xd+3QChzMCVmXz6ebatEYF6sBBekAY8q+w4JRpOjctl/eLrffTenigOXBLXdn9WiPIU0Yl+yF0qej93JKOL/JQz+EmQElGvB1Uscc3R8JzOuOnAGf22kpA==,iv:kaUadkXnCinTiyzcPePkOGZvlF0ruqcXJ/nAARkjWqo=,tag:pyX0fd58qBuSWS8UDY32Ag==,type:str]
-        RedisConnection: ENC[AES256_GCM,data:dnAGnCJny2kq/D70ApcP1iY5X2Qd8yp66r/Q,iv:EdYMRuHFVtZqfYmgQaxteEZbc7YP0vf69jUs5O10qa0=,tag:pWMktJy0f07ow70aVLB3ww==,type:str]
+        RedisConnection: ENC[AES256_GCM,data:+iS+7AzYMyitnBj/Ffn+k+b/opy2StzIJiUaP9s=,iv:oZKBphLoMgDFYlyeMDeLvi0/8rf+LwPVM6WfICB/EG4=,tag:/0HhqJxGkv+zXRy/haw/iA==,type:str]
     AppSettings:
         AppBaseURL: ENC[AES256_GCM,data:IAd0zQm+FDJBk2WrZfNsuB06XHTB,iv:hAcRUhVwRc6i+4/eY21+alwjnctgxVFA186gCdXyWhQ=,tag:W0MGV5FOmo9hyNe9sH8aTw==,type:str]
         Hangfire:
@@ -263,7 +263,7 @@ sops:
           created_at: "2025-03-25T09:20:01Z"
           enc: AQICAHi7RDjxVo0JibSbs68O+yD/kq3TvbDb8YsmwQnZ8PG/0AGbULEceJGAgCWGDKMXPmAaAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAlZBwwWXHb1307msAgEQgDvp0rJFDYFPnyvx8Ko4ofk7Z8wEwI7fiOs/ILJ8ec86kjFt0hxWOCX5CgSjLh0o0o10BMGrICaQDxnTQQ==
           aws_profile: ""
-    lastmodified: "2025-04-17T08:01:49Z"
-    mac: ENC[AES256_GCM,data:7xGXcu9QgponAWA8vmqIlUKwIRpI+1vpd8ziLz+G9o3imL1b9K/zuGJemRdoNfVxb4L44mmPSRnyCyKWAgsemDIBzG+ZrT8rE5IQzApZSCQ6gOG3NUWoPYzxkn3xhZGnOu29CpGMc1nj/oRZZ99I1MMsi4GqiH02AXd46xxZ3Kk=,iv:XgZKtIKFfzYu7rZUg6qzuQorXUn6Mll2Y5YD8wP0uug=,tag:VGDOUrXyZ+YPel1KPiYt+w==,type:str]
+    lastmodified: "2025-04-17T10:43:28Z"
+    mac: ENC[AES256_GCM,data:JT5sQ8v32dOiJ3LcPsSMiqZe3ALekqdZ2kvMfGoa+wTmy1OuHeaPMBMMRtpuhXSwLAUiYJoG9zmhA0Ut6kYOkRvyWm+Gs1kmhVolPH3rDUI/86jzIbeadYUt6E7InDqt8L2OaFsI52o4i2zqCcbSmzH5MQo+49ebdEHWNY+IoT0=,iv:PIRPb7GmnivXYDjLe54p0HwfbWSGhNIZFyBh5a5NNWY=,tag:qjTST4BmvZP3AvlNEqmjug==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/helm/yoma-api/conf/dev/values.yaml
+++ b/helm/yoma-api/conf/dev/values.yaml
@@ -70,15 +70,15 @@ initContainers:
     env:
       - name: PGHOST
         value: &databaseName postgres-yoma
-  - name: check-redis
-    image: redis:7-alpine
+  - name: check-valkey
+    image: valkey/valkey:8-alpine
     imagePullPolicy: IfNotPresent
     command:
       - sh
       - -c
       - |
-        until redis-cli -h redis-master -p 6379 ping; do
-          echo "Waiting for Redis to be ready..."
+        until valkey-cli -h valkey-primary -p 6379 ping; do
+          echo "Waiting for Valkey to be ready..."
           sleep 1
         done
 

--- a/helm/yoma-api/conf/dev/values.yaml
+++ b/helm/yoma-api/conf/dev/values.yaml
@@ -88,7 +88,7 @@ postInstallHook:
     repository: postgres
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "16.1"
+    tag: 17-alpine
   command:
     - /bin/bash
     - -c

--- a/helm/yoma-api/conf/dev/values.yaml
+++ b/helm/yoma-api/conf/dev/values.yaml
@@ -55,7 +55,7 @@ volumeMounts:
 
 initContainers:
   - name: check-postgres
-    image: postgres:16
+    image: postgres:17-alpine
     imagePullPolicy: IfNotPresent
     command:
       - sh
@@ -71,7 +71,7 @@ initContainers:
       - name: PGHOST
         value: &databaseName postgres-yoma
   - name: check-redis
-    image: redis:7
+    image: redis:7-alpine
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -9,7 +9,7 @@ environments:
         ddInjectEnabled: false
         ddProfilingEnabled: false
         postgresEnabled: true
-        redisEnabled: true
+        valkeyEnabled: true
   stage:
     values:
       - namespace: yoma-v3-stage
@@ -17,7 +17,7 @@ environments:
         ddInjectEnabled: true
         ddProfilingEnabled: false
         postgresEnabled: false
-        redisEnabled: false
+        valkeyEnabled: false
   prod:
     values:
       - namespace: yoma-v3-prod
@@ -25,7 +25,7 @@ environments:
         ddInjectEnabled: true
         ddProfilingEnabled: false
         postgresEnabled: false
-        redisEnabled: false
+        valkeyEnabled: false
 ---
 repositories:
 {{ if eq .Environment.Name "local" }}
@@ -107,21 +107,21 @@ releases:
     secrets:
       - ./helm/postgresql-yoma/conf/{{ .Environment.Name }}/secrets.yaml
 
-  - name: redis
+  - name: valkey
     labels:
-      app: redis
+      app: valkey
     namespace: {{ .Values.namespace }}
-    # https://github.com/bitnami/charts/tree/main/bitnami/redis
-    chart: oci://registry-1.docker.io/bitnamicharts/redis
-    version: 20.12.0
-    installed: {{ .Values.redisEnabled }}
+    # https://github.com/bitnami/charts/tree/main/bitnami/valkey
+    chart: oci://registry-1.docker.io/bitnamicharts/valkey
+    version: 3.0.1
+    installed: {{ .Values.valkeyEnabled }}
     values:
-      - fullnameOverride: redis
+      - fullnameOverride: valkey
         architecture: standalone
         auth:
           enabled: false
-        master:
-          count: 1
+        primary:
+          replicaCount: 1
           persistence:
             enabled: false
         replica:

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -80,6 +80,10 @@ releases:
         value: keycloak
       - name: primary.resourcesPreset
         value: medium
+      - name: primary.persistentVolumeClaimRetentionPolicy.enabled
+        value: true
+      - name: primary.persistentVolumeClaimRetentionPolicy.whenDeleted
+        value: Delete
     secrets:
       - ./helm/postgresql-keycloak/conf/{{ .Environment.Name }}/secrets.yaml
 
@@ -100,6 +104,10 @@ releases:
         value: yoma-dev
       - name: primary.resourcesPreset
         value: medium
+      - name: primary.persistentVolumeClaimRetentionPolicy.enabled
+        value: true
+      - name: primary.persistentVolumeClaimRetentionPolicy.whenDeleted
+        value: Delete
       # - name: primary.extendedConfiguration
       #   value: |
       #     log_statement = 'all'
@@ -124,6 +132,9 @@ releases:
           replicaCount: 1
           persistence:
             enabled: false
+          persistentVolumeClaimRetentionPolicy:
+            enabled: true
+            whenDeleted: Delete
         replica:
           replicaCount: 0
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -73,7 +73,7 @@ releases:
     installed: {{ .Values.postgresEnabled }}
     set:
       - name: fullnameOverride
-        value: postgresql-keycloak
+        value: postgres-keycloak
       - name: auth.username
         value: keycloak
       - name: auth.database

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -1,7 +1,7 @@
 name: yoma-v3
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     container_name: yoma-postgres
     # ports:
     #   - 5432:5432
@@ -26,7 +26,7 @@ services:
   #     - "80:80"
 
   redis:
-    image: redis:7.2-alpine
+    image: redis:7-alpine
     container_name: redis
     ports:
       - 6379:6379
@@ -37,7 +37,7 @@ services:
       retries: 3
 
   postgres-init: # Initialise the local postgresql server by populating a test user and organisation(s) for local dev
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     container_name: postgres-init
     depends_on:
       postgres:
@@ -69,7 +69,7 @@ services:
       - ../keycloak/providers/jars:/local-providers # our custom JAR folder, mounted in a separate directory and copied to container
 
   keycloak-pg:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     container_name: keycloak-pg
     ports:
       - 5432:5432

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -25,13 +25,13 @@ services:
   #   ports:
   #     - "80:80"
 
-  redis:
-    image: redis:7-alpine
-    container_name: redis
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: valkey
     ports:
       - 6379:6379
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -243,7 +243,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Local
       ASPNETCORE_URLS: "http://+:5000"
       ConnectionStrings__SQLConnection: "Host=postgres;Port=5432;Database=yoma-dev;Username=postgres;Password=P@ssword1;SslMode=Prefer;Trust Server Certificate=True;Include Error Detail=true;"
-      ConnectionStrings__RedisConnection: "redis:6379"
+      ConnectionStrings__RedisConnection: "valkey:6379"
       Logging__LogLevel__Default: "Debug"
       Logging__LogLevel__Microsoft: "Debug"
       Logging__LogLevel__Microsoft.Hosting.Lifetime: "Information"
@@ -259,7 +259,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
+      valkey:
         condition: service_healthy
 
   yoma-api-health:


### PR DESCRIPTION
* On a fresh deployment of Yoma API, we only want a single replica due
  to DB migrations
* If multiple replicas are started up on a fresh deploy, one of them
  will error and hang indefinitely (until startup probe restarts it)
* Make Helm Plugins an environment variable to deduplicate and make
  things a bit more maintainable