### PR TITLE
Add proxy busy buffer size for nginx 4.13

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -410,8 +410,8 @@ jobs:
 
     env:
       TAILSCALE_VERSION: latest
-      HELMFILE_VERSION: v0.171.0
-      HELM_VERSION: v3.17.3
+      HELMFILE_VERSION: v1.1.2
+      HELM_VERSION: v3.18.4
       TAG: ${{ needs.docker-push.outputs.image_version }}
 
     concurrency:

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -5,6 +5,7 @@ ingress:
     enabled: false
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
@@ -18,6 +19,7 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/app-root: /auth
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
@@ -28,6 +30,7 @@ ingress:
     enabled: false
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -75,6 +75,7 @@ ingress:
     className: nginx-internal
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
@@ -88,6 +89,7 @@ ingress:
     className: nginx-external
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;

--- a/helm/yoma-web/conf/dev/values.yaml
+++ b/helm/yoma-web/conf/dev/values.yaml
@@ -15,6 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: dev.yoma.world

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -15,6 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.world') {
@@ -46,6 +47,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.world') {

--- a/helm/yoma-web/conf/stage/values.yaml
+++ b/helm/yoma-web/conf/stage/values.yaml
@@ -15,6 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: stage.yoma.world
@@ -24,6 +25,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: stage.yoma.world


### PR DESCRIPTION
Add `nginx.ingress.kubernetes.io/proxy-busy-buffer-size` annotation
to match existing `proxy-buffer-size` values across all ingress
configurations. This is required due to a breaking change in Ingress
Nginx 4.13 where `proxy-busy-buffer-size` must be equal to or greater
than `proxy-buffer-size`.

Also update CI/CD dependencies:
* Upgrade Helmfile from v0.171.0 to v1.1.2
* Upgrade Helm from v3.17.3 to v3.18.4

Affected services:
* Keycloak ingress configurations
* Yoma API internal and external ingress
* Yoma Web ingress for dev, stage, and prod environments

---

https://github.com/kubernetes/ingress-nginx/issues/13598