### PR TITLE
Fix nginx annotation typo

### DIFF
--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -5,7 +5,7 @@ ingress:
     enabled: false
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
@@ -19,7 +19,7 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/app-root: /auth
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
@@ -30,7 +30,7 @@ ingress:
     enabled: false
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -75,7 +75,7 @@ ingress:
     className: nginx-internal
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
@@ -89,7 +89,7 @@ ingress:
     className: nginx-external
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;

--- a/helm/yoma-web/conf/dev/values.yaml
+++ b/helm/yoma-web/conf/dev/values.yaml
@@ -15,7 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: dev.yoma.world

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -15,7 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.world') {
@@ -47,7 +47,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.world') {

--- a/helm/yoma-web/conf/stage/values.yaml
+++ b/helm/yoma-web/conf/stage/values.yaml
@@ -15,7 +15,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: stage.yoma.world
@@ -25,7 +25,7 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
-      nginx.ingress.kubernetes.io/proxy-busy-buffer-size: 512k
+      nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
       nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: stage.yoma.world


### PR DESCRIPTION
Correct `proxy-busy-buffer-size` to `proxy-busy-buffers-size` in all
nginx ingress annotations. The correct annotation name includes
"buffers" (plural) not "buffer" (singular).