### PR TITLE
Fix Action Link usage matching with UsernameClaimed snapshot and curr…

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/ActionLink/Services/LinkService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/ActionLink/Services/LinkService.cs
@@ -474,8 +474,8 @@ namespace Yoma.Core.Domain.ActionLink.Services
                     (x, u) => new { x.id, u })
                 .GroupJoin(
                     _linkUsageLogRepository.Query().Where(l => l.LinkId == link.Id),
-                    x => x.u != null ? x.u.Id : null,
-                    l => (Guid?)l.UserId,
+                    x => x.id, // distribution list / identifier
+                    l => (l.UsernameClaimed ?? l.Username).ToLower(),
                     (x, logs) => new { x.id, x.u, logs })
                 .SelectMany(
                     x => x.logs.DefaultIfEmpty(),
@@ -595,8 +595,8 @@ namespace Yoma.Core.Domain.ActionLink.Services
                     (x, u) => new { x.id, u })
                 .GroupJoin(
                     _linkUsageLogRepository.Query().Where(l => l.LinkId == link.Id),
-                    x => x.u != null ? x.u.Id : null,
-                    l => (Guid?)l.UserId,
+                    x => x.id, // distribution list / identifier
+                    l => (l.UsernameClaimed ?? l.Username).ToLower(),
                     (x, logs) => new { x.id, x.u, logs })
                 .SelectMany(
                     x => x.logs.DefaultIfEmpty(),


### PR DESCRIPTION
…ent user resolution

- Use UsernameClaimed from usage logs to persist original distribution list match
- Join usage logs on distribution list identifier instead of UserId to preserve claim state when usernames change
- Prioritize Email > PhoneNumber > Username for user matching to handle username type changes
- Ensure final results reflect latest user details while maintaining historical claim accuracy