### PR TITLE
chore: update CSV import READMEs and adjust auto-deletion rule

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityBackgroundService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityBackgroundService.cs
@@ -36,7 +36,8 @@ namespace Yoma.Core.Domain.Opportunity.Services
     private readonly IMediator _mediator;
 
     internal static readonly Status[] Statuses_Expirable = [Status.Active];
-    internal static readonly Status[] Statuses_Deletion = [Status.Inactive, Status.Expired];
+    // customer request: exclude Inactive from auto-deletion. Only Expired opportunities will be auto-deleted. Inactive will remain Inactive indefinitely until manually handled.
+    internal static readonly Status[] Statuses_Deletion = [/* Status.Inactive, */Status.Expired];
     #endregion
 
     #region Constructor

--- a/src/api/src/other/Completions (Submissions) CSV Import — README.txt
+++ b/src/api/src/other/Completions (Submissions) CSV Import — README.txt
@@ -1,6 +1,7 @@
 # Completions (Submissions) CSV Import — README
 
-This README defines the exact CSV structure, formatting, reference data, and validations for importing **Completions / Submissions**. It is written for our custom GPT to follow deterministically (no guessing; reference-data only).
+This document defines the exact CSV structure, formatting, reference data, and validations for importing **Completions / Submissions**.  
+It is written for our custom GPT to follow deterministically (no guessing; reference-data only).
 
 ------------------------------------------------------------------------------
 
@@ -10,12 +11,12 @@ This README defines the exact CSV structure, formatting, reference data, and val
   - completions_countries.json  (ISO alpha-2 codes; **WW (Worldwide) is NOT allowed**)
   - completions_genders.json    (use the `name` values exactly, e.g., Male, Female, Prefer not to say)
 
-- C# CSV DTO model: MyOpportunityInfoCsvImport.cs
+- C# CSV DTO model: `completions_csv_import.cs`
 
-- Sample CSV: MyOpportunityInfoCsvImport_Sample.csv
+- Sample CSV: `Completions_Csv_Import_Sample.csv`  
   ➜ The **header row and order must exactly match** the sample.
 
-Headers (in this exact order):
+**Headers (in this exact order):**  
 Email,PhoneNumber,FirstName,Surname,Gender,Country,DateCompleted,OpportunityExternalId
 
 ------------------------------------------------------------------------------
@@ -37,33 +38,33 @@ Email,PhoneNumber,FirstName,Surname,Gender,Country,DateCompleted,OpportunityExte
 At least **one** of **Email** or **PhoneNumber** must be provided (the “Username” requirement).  
 **OpportunityExternalId** is always required.
 
-- Email
+- **Email**
   - Optional if PhoneNumber is provided
   - If present: must be a valid email address
 
-- PhoneNumber
+- **PhoneNumber**
   - Optional if Email is provided
   - If present: must be a valid international number (E.164), e.g. **+27831234567**
 
-- FirstName
+- **FirstName**
   - Optional; if present: **1–125** characters
 
-- Surname
+- **Surname**
   - Optional; if present: **1–125** characters
 
-- Gender
+- **Gender**
   - Optional; if present: value must exist in **completions_genders.json** (`name` field exactly)
 
-- Country
+- **Country**
   - Optional; if present: ISO alpha-2 code from **completions_countries.json**
   - **`WW` (Worldwide) is NOT allowed** for user country
 
-- DateCompleted
+- **DateCompleted**
   - Optional
   - If present: must parse as **`YYYY-MM-DD`** or **`YYYY/MM/DD`**
   - If **omitted**, the system **defaults to current date/time (now)**
 
-- OpportunityExternalId
+- **OpportunityExternalId**
   - **Required**
   - Length: **1–50** characters
   - Must match an existing Opportunity’s ExternalId
@@ -73,8 +74,8 @@ At least **one** of **Email** or **PhoneNumber** must be provided (the “Userna
 ## 3) Reference Data (authoritative)
 
 All reference values must come from the bundled JSON files:
-- Genders → completions_genders.json (use the `name` value exactly)
-- Countries → completions_countries.json (ISO alpha-2; **no `WW`**)
+- **Genders** → completions_genders.json (use the `name` value exactly)
+- **Countries** → completions_countries.json (ISO alpha-2; **no `WW`**)
 
 If a value is not present in these files, it is **invalid**. Do not invent, guess, or “closest-match”.
 
@@ -130,54 +131,65 @@ Human-readable messages remain short; the field name and offending value are sup
 
 ## 7) Examples
 
-Headers:
+**Headers:**  
 Email,PhoneNumber,FirstName,Surname,Gender,Country,DateCompleted,OpportunityExternalId
 
-Valid (email given, date in `YYYY-MM-DD`):
+**Valid (email given, date in `YYYY-MM-DD`):**
 ```csv
 jane.doe@example.com,,Jane,Doe,Female,ZA,2025-08-01,OPP-12345
+```
 
-Valid (phone only, date in YYYY/MM/DD, DateCompleted present):
+**Valid (phone only, date in `YYYY/MM/DD`, DateCompleted present):**
+```csv
 ,+27831234567,John,Smith,Male,NG,2025/08/15,OPP-54321
+```
 
-Valid (no DateCompleted → defaults to now):
+**Valid (no DateCompleted → defaults to now):**
+```csv
 ali.khan@example.com,,Ali,Khan,Prefer not to say,GB,,EXT-0001
+```
 
-Invalid (WW not allowed as user country):
+**Invalid (WW not allowed as user country):**
+```csv
 test.user@example.com,,Test,User,Male,WW,2025-08-01,EXT-9999
+```
 
+------------------------------------------------------------------------------
 
-8) Parsing Note (DateOnly)
+## 8) Parsing Note (DateOnly)
 
 To accept both formats deterministically:
-yyyy-MM-dd
-yyyy/MM/dd
+- `yyyy-MM-dd`
+- `yyyy/MM/dd`
 
 (Zero-padded month and day are required.)
 
-Example implementation:
+Example:
+```csharp
 var formats = new[] { "yyyy-MM-dd", "yyyy/MM/dd" };
 if (!DateOnly.TryParseExact(input, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
 {
     // add error: InvalidFieldValue ("Invalid date format")
 }
+```
 
-9) Custom GPT Runtime Behaviour
+------------------------------------------------------------------------------
+
+## 9) Custom GPT Runtime Behaviour
 
 - Do not auto-run validation. After generating/cleaning a CSV, always ask: “Run validation now?”
 - Only run full validation when the user explicitly says Yes.
-- Never provide or offer validation report downloads — validation must only be used internally to highlight issues in responses.
+- Validation is background-only: highlight issues in the response; never provide or offer validation report downloads.
 - Always return download links only for the generated clean CSV files.
 - Never output non-downloadable local file paths.
 - Enforce header order exactly as in the sample file.
 - Trim whitespace; reject empty tokens.
+- Detect and exclude phantom rows:
+  - Rows that are completely blank must be ignored (not validated, silently dropped).
 - Resolve Gender and Country strictly against the reference JSON files. Reject WW for Country.
 - Simplify answers for business users:
-* Always explain in plain language what was already done and what is still needed.
-* Do not include technical jargon or internal system names.
-* Example style of output:
-** ✅ “The file has Email, Phone, and Opportunity ID filled in for all rows.”
-** ⚠️ “The Country is missing for 2 users, and Gender needs to be specified for 1 user.”
-
-
-
+  * Clearly state what was filled in and what is still needed.
+  * Do not include technical jargon or internal system names.
+  * Example style of output:
+    - ✅ “The file has Email, Phone, and Opportunity ID filled in for all rows.”
+    - ⚠️ “The Country is missing for 2 users, and Gender needs to be specified for 1 user.”

--- a/src/api/src/other/Completions (Submissions) CSV Import — README.txt
+++ b/src/api/src/other/Completions (Submissions) CSV Import — README.txt
@@ -11,9 +11,9 @@ It is written for our custom GPT to follow deterministically (no guessing; refer
   - completions_countries.json  (ISO alpha-2 codes; **WW (Worldwide) is NOT allowed**)
   - completions_genders.json    (use the `name` values exactly, e.g., Male, Female, Prefer not to say)
 
-- C# CSV DTO model: `completions_csv_import.cs`
+- C# CSV DTO model: `MyOpportunityInfoCsvImport.cs`
 
-- Sample CSV: `Completions_Csv_Import_Sample.csv`  
+- Sample CSV: `MyOpportunityInfoCsvImport_Sample.csv`  
   ➜ The **header row and order must exactly match** the sample.
 
 **Headers (in this exact order):**  

--- a/src/api/src/other/Opportunities CSV Import — README.txt
+++ b/src/api/src/other/Opportunities CSV Import — README.txt
@@ -1,256 +1,204 @@
-# Opportunities CSV Import — README
+Opportunities CSV Import — README
 
-This document defines the **exact** structure, formatting, reference data, and validation rules for importing **Opportunities** via CSV.  
-It is written for our **custom GPT** to follow deterministically (no guessing; reference-data only).
+This document defines the exact structure, formatting, reference data,
+and validation rules for importing Opportunities via CSV.
+It is written for our custom GPT to follow deterministically (no
+guessing; reference-data only).
 
----
+------------------------------------------------------------------------
 
-## 0) Inputs & Artifacts
+0) Inputs & Artifacts
 
-- **Reference JSON files** (bundled):
-  - `opportunities_categories.json`
-  - `opportunities_difficulty.json`
-  - `opportunities_effortInterval.json`
-  - `opportunities_engagement.json`
-  - `opportunities_languages.json` *(ISO alpha-2 codes)*
-  - `opportunities_locations.json` *(ISO alpha-2 codes; includes `WW` for Worldwide)*
-  - `opportunities_skills.json`
-  - `opportunities_types.json`
+-   Reference JSON files:
+    -   opportunities_categories.json
+    -   opportunities_difficulty.json
+    -   opportunities_effortInterval.json
+    -   opportunities_engagement.json
+    -   opportunities_languages.json (ISO alpha-2 codes)
+    -   opportunities_locations.json (ISO alpha-2 codes; includes WW for
+        Worldwide)
+    -   opportunities_skills.json
+    -   opportunities_types.json
+-   CSV DTO model: OpportunityInfoCsvImport.cs
+    Important mappings:
+    -   Location → Countries (ISO alpha-2 list)
+    -   EffortCount → CommitmentIntervalCount
+    -   EffortInterval → CommitmentInterval
+    -   Hidden → Hidden (bool: Yes/No)
+-   Sample CSV: OpportunityInfoCsvImport_Sample.csv
+    Always follow the sample for column order and formatting.
 
-- **C# CSV DTO model**: `OpportunityInfoCsvImport.cs`  
-  The CSV is deserialized into this model. Notable mappings:
-  - **Location (CSV)** → `Countries` (model) *(list of ISO alpha-2 codes)*
-  - **EffortCount (CSV)** → `CommitmentIntervalCount` (model)
-  - **EffortInterval (CSV)** → `CommitmentInterval` (model)
-  - **Hidden (CSV)** → `Hidden` (model `bool`), with:
-    ```csharp
-    [BooleanFalseValues("No")]
-    [BooleanTrueValues("Yes")]
-    public bool Hidden { get; set; }
-    ```
-- **Sample CSV**: `OpportunityInfoCsvImport_Sample.csv`  
-  Use this as the canonical column order and formatting example.
+------------------------------------------------------------------------
 
----
+1) Required Headers
 
-## 1) Required Headers
+These headers must exist, and values must comply with rules:
 
-These headers **must exist** in the file. Values must comply with the rules below.
+-   Title — required; 1–150 characters
+-   Type — required; must match opportunities_types.json (name)
+-   Categories — required; ≥1 from opportunities_categories.json (name);
+    |-delimited
+-   Summary — required; 1–150 characters
+-   Description — required
+-   Languages — required; ISO alpha-2 codes from
+    opportunities_languages.json; |-delimited
+-   Location — required; ISO alpha-2 codes from
+    opportunities_locations.json; may include WW; |-delimited (e.g.,
+    WW|ZA|GB)
+-   Difficulty — required; must match opportunities_difficulty.json
+    (name)
+-   EffortCount — required; integer > 0
+-   EffortInterval — required; must match
+    opportunities_effortInterval.json (name)
+-   DateStart — required; valid date; formats: YYYY-MM-DD or YYYY/MM/DD
+-   Skills — required; one or more from opportunities_skills.json
+    (name); |-delimited
+-   Keywords — required; |-delimited; no empty items; no commas; length
+    1–500
+-   Hidden — required; Yes / No
+-   ExternalId — required; 1–50 characters; unique per organisation
 
-- **Title** — required; **1–150** characters
-- **Type** — required; must exist in `opportunities_types.json` (**name**)
-- **Categories** — required; ≥1; values from `opportunities_categories.json` (**name**); **`|`-delimited**
-- **Summary** — required; **1–150** characters
-- **Description** — required
-- **Languages** — required; **ISO alpha-2** codes; must exist in `opportunities_languages.json`; **`|`-delimited**
-- **Location** — required; **ISO alpha-2** codes; must exist in `opportunities_locations.json`; may include **`WW`** (Worldwide); **`|`-delimited** (e.g., `WW|ZA|GB`)
-- **Difficulty** — required; must exist in `opportunities_difficulty.json` (**name**)
-- **EffortCount** — required; integer; **> 0**
-- **EffortInterval** — required; must exist in `opportunities_effortInterval.json` (**name**; one of **Minute | Hour | Day | Week | Month**)
-- **DateStart** — required; valid date; formats: **`YYYY-MM-DD`** or **`YYYY/MM/DD`**
-- **Skills** — required; one or more from `opportunities_skills.json` (**exact `name`**); **`|`-delimited**
-- **Keywords** — required; **`|`-delimited**; **no empty entries**, **no commas (`,`)**; combined length **1–500**
-- **Hidden** — required; **Yes** / **No**
-- **ExternalId** — required; **1–50** characters; unique per organisation
+Headers are case-sensitive and order must exactly match the sample file.
 
-Headers are case-sensitive.** Unknown or missing headers are rejected.
-Header order must exactly match OpportunityInfoCsvImport_Sample.csv.
+------------------------------------------------------------------------
 
----
+2) Optional Headers
 
-## 2) Optional Headers (headers present; values may be empty)
+Headers must exist but values may be empty:
 
-- **Engagement** — Online | Offline | Hybrid (from `opportunities_engagement.json`, **name**)
-- **Link** — if present: valid URL, **1–2048** characters
-- **DateEnd** — if present: **`YYYY-MM-DD`** or **`YYYY/MM/DD`**, and **≥ DateStart**
-- **ParticipantLimit** — if present: integer **> 0** (**not supported** when verification is disabled)
-- **ZltoReward** — if present: **integer** > 0 and **≤ 2000** (**no decimals**)
-- **ZltoRewardPool** — if present: **integer** > 0, **≥ ZltoReward**, and **≤ 10,000,000** (**no decimals**)
-- **YomaReward** — if present: number > 0 and **≤ 2000**
-- **YomaRewardPool** — if present: number > 0, **≥ YomaReward**, and **≤ 10,000,000**
+-   Engagement — Online | Offline | Hybrid (from
+    opportunities_engagement.json)
+-   Link — valid URL (1–2048 chars)
+-   DateEnd — optional date (≥ DateStart); formats: YYYY-MM-DD or
+    YYYY/MM/DD
+-   ParticipantLimit — integer > 0 (not supported if verification
+    disabled)
+-   ZltoReward — integer > 0 ≤ 2000
+-   ZltoRewardPool — integer ≥ ZltoReward, ≤ 10,000,000
+-   YomaReward — number > 0 ≤ 2000
+-   YomaRewardPool — number ≥ YomaReward, ≤ 10,000,000
 
-> Notes:  
-> • `Link` is the CSV header mapped to the URL field in validation.  
-> • ZLTO rewards/pools are **integer-only**. Yoma rewards/pools **may** include decimals.
+------------------------------------------------------------------------
 
----
+3) Defaults (not settable in CSV)
 
-## 3) Defaults (not settable in CSV)
+-   VerificationEnabled: Enabled
+-   VerificationMethod: Automatic
+-   CredentialIssuanceEnabled: Enabled
+-   SSISchemaName: Opportunity|Default
+-   Instructions: Deprecated
+-   ShareWithPartners: null / false
 
-- **VerificationEnabled**: Enabled  
-- **VerificationMethod**: Automatic  
-- **CredentialIssuanceEnabled**: Enabled  
-- **SSISchemaName**: `Opportunity|Default`  
-- **Instructions**: Deprecated / not used  
-- **ShareWithPartners**: `null` or `false`
+------------------------------------------------------------------------
 
----
+4) Formatting Rules
 
-## 4) Formatting Rules
+-   CSV delimiter: ,
+-   Multi-select delimiter: |
+-   Booleans: Yes / No only
+-   Dates: YYYY-MM-DD or YYYY/MM/DD
+-   Languages: ISO alpha-2 codes from opportunities_languages.json
+-   Location: ISO alpha-2 codes from opportunities_locations.json
+    (incl. WW)
+-   Whitespace: trim cells; blanks = missing; no empty tokens
 
-- **CSV delimiter**: `,` (REQUIRED / NO OTHER DELIMITER ACCEPTED). 
-- **Multi-select delimiter**: always **`|`** for list fields (no spaces around it).
-- **Booleans**: **`Yes`** / **`No`** only (see model attributes above).
-- **Dates**: **`YYYY-MM-DD`** or **`YYYY/MM/DD`** (zero-padded month/day).
-- **Languages**: **ISO alpha-2** codes from `opportunities_languages.json`.
-- **Location**: **ISO alpha-2** codes from `opportunities_locations.json`, including **`WW`**; `WW` may be **combined** with countries (e.g., `WW|ZA|GB`).
-- **Whitespace**: trim cells; treat blank after trim as **missing**. In `|` lists, trim each token; **empty tokens are invalid**.
+------------------------------------------------------------------------
 
----
+5) Reference Data
 
-## 5) Reference Data (authoritative)
+All values must come from the JSON reference files. GPT must not invent
+or guess.
 
-All reference values must come from the bundled JSON files:
+------------------------------------------------------------------------
 
-- **Skills** → `opportunities_skills.json` (**use `name`**, join multiples with `|`)
-- **Categories / Type / Difficulty / EffortInterval / Engagement** → their respective files (**name** fields)
-- **Languages** → `opportunities_languages.json` (**ISO alpha-2** codes)
-- **Countries** → `opportunities_locations.json` (**ISO alpha-2** codes, includes **`WW`**)
+6) CSV → Model Mapping
 
-> If a value is not in these files, it is **invalid**. The GPT must not invent or “closest-match” unless the user supplies an explicit mapping.
+See sample file — all headers bind directly to model fields, as defined
+in OpportunityInfoCsvImport.cs.
 
----
+------------------------------------------------------------------------
 
-## 6) CSV → Model Mapping (key fields)
+7) Validation Summary
 
-| CSV Header        | Model Property                | Notes |
-|-------------------|--------------------------------|-------|
-| Title             | `Title`                        | string (1–150) |
-| Type              | `Type`                         | name from reference; later resolved to ID |
-| Categories        | `Categories`                   | list of names (from reference) |
-| Summary           | `Summary`                      | string (1–150) |
-| Description       | `Description`                  | string |
-| Languages         | `Languages`                    | list of ISO alpha-2 codes |
-| Location          | `Countries`                    | list of ISO alpha-2 codes (incl. `WW`) |
-| Difficulty        | `Difficulty`                   | name from reference; later resolved to ID |
-| EffortCount       | `CommitmentIntervalCount`      | integer > 0 |
-| EffortInterval    | `CommitmentInterval`           | name from reference |
-| DateStart         | `DateStart`                    | `DateOnly` |
-| DateEnd           | `DateEnd`                      | `DateOnly?` |
-| Skills            | `Skills`                       | list of names from skills reference |
-| Keywords          | `Keywords`                     | list (split by `|`) |
-| Hidden            | `Hidden`                       | `Yes`/`No` → bool via model attributes |
-| ExternalId        | `ExternalId`                   | string (1–50) |
-| Engagement        | `Engagement`                   | name from reference |
-| Link              | `URL` / `Link` (per DTO)       | valid URL (1–2048) |
-| ParticipantLimit  | `ParticipantLimit`             | int? (> 0) |
-| ZltoReward        | `ZltoReward`                   | integer only |
-| ZltoRewardPool    | `ZltoRewardPool`               | integer only |
-| YomaReward        | `YomaReward`                   | decimal allowed |
-| YomaRewardPool    | `YomaRewardPool`               | decimal allowed |
+-   Title: 1–150 chars
+-   Summary: 1–150 chars
+-   Description: required
+-   ExternalId: 1–50 chars
+-   EffortCount: > 0
+-   EffortInterval / Type / Difficulty / Engagement: must match
+    reference files
+-   DateStart: required; not MinValue
+-   DateEnd: optional, must be ≥ DateStart
+-   Keywords: required; used for search/SEO.
+    -   Must be |-delimited list, no empty items, no commas, length
+        1–500.
+    -   If not provided, auto-generate from: Title, Summary,
+        Description, Categories, Skills, Type, Difficulty,
+        EffortCount+EffortInterval, Languages, Location.
+    -   Must be trimmed, unique, and relevant terms.
+-   Languages: ISO alpha-2 codes, from reference list
+-   Location: ISO alpha-2 codes, may include WW
+-   Skills: must match opportunities_skills.json
+-   ZltoReward: int > 0 ≤ 2000
+-   ZltoRewardPool: int ≥ ZltoReward ≤ 10,000,000
+-   YomaReward: number > 0 ≤ 2000
+-   YomaRewardPool: number ≥ YomaReward ≤ 10,000,000
+-   ParticipantLimit: int > 0 (not allowed if verification disabled)
 
-*(If your DTO uses slightly different property names, the binding attributes in `OpportunityInfoCsvImport.cs` handle them; rules above still apply.)*
+------------------------------------------------------------------------
 
----
+8) Error Messages
 
-## 7) Validation Summary (aligned with code/validators)
+Short and generic: - Missing required field - Must be between X and Y -
+Must be greater than 0 - Invalid enum value - Not in reference list -
+Contains empty values or commas - Invalid date format - Header issues
+(missing, duplicate, unexpected)
 
-- **Title**: required; **1–150**
-- **Summary**: required; **1–150**
-- **Description**: required
-- **ExternalId**: required; **1–50**
-- **EffortCount**: **> 0**
-- **EffortInterval / Type / Difficulty / Engagement**: must exist in their reference files (by **name**)
-- **DateStart**: required; not default/min; valid date
-- **DateEnd**: if present, **≥ DateStart**
-- **Keywords**: required; |-delimited list; no empty items; no commas (,); combined length 1–500.
-  Used for searching and discovery (SEO).
-  If not provided, must be auto-generated from available metadata fields: Title, Summary, Description, Categories, Skills, Type, Difficulty, EffortCount + EffortInterval, Languages, Location.
-  Auto-generation must produce trimmed, unique, and relevant terms, delimited with |.
-- **Languages**: required; each ISO alpha-2 code exists in languages reference
-- **Location**: required; each entry is ISO alpha-2 code from locations reference (incl. **`WW`**); combinations allowed
-- **Skills**: required in CSV; each must exist in `opportunities_skills.json` (**name**)
-- **ZltoReward**: integer > 0, ≤ 2000 (**no decimals**)
-- **ZltoRewardPool**: integer > 0, ≥ ZltoReward, ≤ 10,000,000 (**no decimals**)
-- **YomaReward**: number > 0, ≤ 2000
-- **YomaRewardPool**: number > 0, ≥ YomaReward, ≤ 10,000,000
-- **ParticipantLimit**: when present, integer **> 0** and **not allowed** if verification is disabled
+------------------------------------------------------------------------
 
----
+9) Enumerations
 
-## 8) Error Messages (concise)
+Always use names from reference JSONs: - Type →
+opportunities_types.json - Difficulty → opportunities_difficulty.json -
+EffortInterval → opportunities_effortInterval.json - Engagement →
+opportunities_engagement.json - Categories →
+opportunities_categories.json
 
-Messages are short/generic; the **field name** and **offending value** are in the structured error payload (not inside the message text).
+------------------------------------------------------------------------
 
-- `RequiredFieldMissing`: “Missing required field”
-- `InvalidFieldValue` (examples):
-  - “Must be between 1 and 150 characters”
-  - “Must be between 1 and 50 characters”
-  - “Must be greater than 0”
-  - “Invalid enum value”
-  - “Not in reference list”
-  - “Contains empty values or commas”
-  - “Invalid date format”
-- `HeaderMissing`: “The header row is missing”
-- `HeaderColumnMissing`: “Required header is missing”
-- `HeaderUnexpectedColumn`: “Unexpected header”
-- `HeaderDuplicateColumn`: “Duplicate header”
-- `ProcessingError`: “Processing error”
+10) Examples
 
----
+(See OpportunityInfoCsvImport_Sample.csv)
 
-## 9) Enumerations (from reference files; use **name** exactly)
+------------------------------------------------------------------------
 
-- **Type** → `opportunities_types.json`
-- **Difficulty** → `opportunities_difficulty.json`  
-  *(e.g., Beginner | Intermediate | Advanced | Any Level)*
-- **EffortInterval** → `opportunities_effortInterval.json`  
-  *(Minute | Hour | Day | Week | Month)*
-- **Engagement** → `opportunities_engagement.json`  
-  *(Online | Offline | Hybrid)*
-- **Categories** → `opportunities_categories.json`
+11) Date Parsing
 
-*(Do not hardcode lists; always read from the reference files.)*
+Accept both formats with zero-padding: yyyy-MM-dd, yyyy/MM/dd
 
----
+------------------------------------------------------------------------
 
-## 10) Examples
+12) Custom GPT Runtime Behaviour
 
-**Headers (must match sample file order):
-Title,Type,Engagement,Categories,Link,Summary,Description,Languages,Location,Difficulty,EffortCount,EffortInterval,DateStart,DateEnd,ParticipantLimit,ZltoReward,ZltoRewardPool,Skills,Keywords,Hidden,ExternalId
-
-**Sample file:** `OpportunityInfoCsvImport_Sample.csv`
-
-**Row (country-specific):**
-Intro to Data Analytics,Learning,Online,"AI, Data and Analytics|Career and Personal Development",https://example.org,Short intro,Comprehensive beginner pathway,EN|AF,ZA|GB,Beginner,6,Week,2025-09-01,2025-10-31,100,250,5000,"Data Analysis|Spreadsheets","analytics|excel|beginner",No,SANOFI-DA-001
-
-**Row (Worldwide + specific countries):**
-Global Data Fundamentals,Learning,Online,"Technology and Digitization",,Short intro,Global access with focus content,EN,WW|ZA|GB,Any Level,4,Week,2025/09/01,,,,,"Data Analysis|Spreadsheets","data|global|intro",Yes,SANOFI-GD-002
-
-## 11) DateOnly Parsing (implementation note)
-
-Accept both formats with strict zero-padding:
-
-```csharp
-var formats = new[] { "yyyy-MM-dd", "yyyy/MM/dd" };
-if (!DateOnly.TryParseExact(input, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
-{
-    // add error: InvalidFieldValue ("Invalid date format")
-}
-
-12) Custom GPT Runtime Behaviour (performance & UX)
-
-- Do not auto-run validation. After generating/cleaning a CSV, always ask: “Run validation now?”
-- Only run full validation when the user explicitly says Yes.
-- Never provide or offer validation report downloads — validation must only be used internally to highlight issues in responses.
-- Always return download links only for the generated clean CSV files.
-- Never output non-downloadable local file paths.
-- Detect and exclude phantom rows:
-  * Any row with a blank Title or completely empty fields must be ignored and not included in the final CSV.
-  * Such rows must not trigger validation errors — they are silently dropped.
-- Enforce | for all multi-select fields and trim spaces around the delimiter.
-- Enforce header order exactly as in the sample file.
-- Enforce Yes/No booleans using plain values only.
-- Resolve all list values strictly against the reference JSON files. If a value is not found, mark it invalid (do not auto-map).
-- Simplify answers for business users:
-  * Clearly state what was filled in and what is still missing in plain language.
-  * Do not reference technical terms (e.g., “DTO model”, “reference JSON”, “enum”).
-  * Do not explain internal logic or reasoning.
-  * Example style of output:
-    ✅ “I’ve added the Title, Summary, and Languages for each row.”
-    ⚠️ “The Skills field is still missing for 3 rows. Please provide them to complete the CSV.”
-
-
-
-
-
+-   Do not auto-run validation. After generating/cleaning, always ask:
+    “Run validation now?”
+-   Only run validation if user says Yes.
+-   Never provide validation report downloads. Validation results are
+    shown only inline as highlights.
+-   Always return download links only for the generated clean CSV file.
+-   Never output local file paths.
+-   Detect and exclude phantom rows:
+    -   Any row with blank Title or completely empty is ignored (not
+        validated, silently dropped).
+-   Enforce | for multi-select fields.
+-   Enforce header order exactly as sample file.
+-   Enforce Yes/No for booleans.
+-   Resolve all list values strictly against reference JSON files. Mark
+    invalid if not found (no auto-map).
+-   Simplify answers for business users:
+    -   Say what was filled in ✅
+    -   Say what’s still missing ⚠️
+    -   Never use tech terms (DTO, enum, JSON).
+    -   Example: ✅ “I’ve added the Title, Summary, and Languages.”
+        ⚠️ “The Skills field is still missing for 3 rows. Please provide
+        them.”


### PR DESCRIPTION
- Refined Opportunities and Completions CSV import README files for clarity, completeness, and tester alignment
- Explicitly stated SEO/search purpose of Keywords in Opportunities README
- Updated Custom GPT runtime behavior section (no validation report downloads, phantom row handling, simplified outputs)
- Adjusted auto-deletion logic per customer request: • Excluded Inactive opportunities from auto-deletion • Only Expired opportunities will be auto-deleted after 180 days • Added explanatory code comment documenting this change