### PR TITLE
chore(csv-import): handle empty strings as null and improve header mi…

### DIFF
--- a/src/api/src/domain/Yoma.Core.Domain/Core/Helpers/CSVImportHelper.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Core/Helpers/CSVImportHelper.cs
@@ -94,7 +94,7 @@ namespace Yoma.Core.Domain.Core.Helpers
       var recognizedCount = header.Count(h => h != null && modelHeaders.Contains(h));
       if (recognizedCount == 0)
       {
-        AddError(errors, CSVImportErrorType.HeaderMissing, "The header row is missing. The first row appears to be a record.", 1);
+        AddError(errors, CSVImportErrorType.HeaderMissing, "Header row appears to be missing — the first row does not look like a valid header and may instead be a record or incorrectly formatted", 1);
         return;
       }
 

--- a/src/api/src/domain/Yoma.Core.Domain/MyOpportunity/Services/MyOpportunityService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/MyOpportunity/Services/MyOpportunityService.cs
@@ -1104,6 +1104,7 @@ namespace Yoma.Core.Domain.MyOpportunity.Services
 
       var errors = new List<CSVImportErrorRow>();
       using var csv = new CsvHelper.CsvReader(reader, CSVImportHelper.CreateConfig<MyOpportunityInfoCsvImport>(errors));
+      csv.Context.TypeConverterOptionsCache.GetOptions<string>().NullValues.Add(string.Empty);
 
       // Validate header before reading data rows
       // Stop if errors — prevents invalid column-to-property mapping

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Enumerations.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Enumerations.cs
@@ -5,7 +5,7 @@ namespace Yoma.Core.Domain.Opportunity
     Active, //flagged as expired provided ended (notified)
     Deleted,
     Expired, //flagged as deleted if expired and not modified for x days
-    Inactive, //flagged as deleted if inactive and not modified for x days
+    Inactive, //customer request: exclude Inactive from auto-deletion. Only Expired opportunities will be auto-deleted. Inactive will remain Inactive indefinitely until manually handled; flagged as deleted if inactive and not modified for x days
   }
 
   public enum VerificationMethod

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
@@ -1051,6 +1051,7 @@ namespace Yoma.Core.Domain.Opportunity.Services
 
       var errors = new List<CSVImportErrorRow>();
       using var csv = new CsvHelper.CsvReader(reader, CSVImportHelper.CreateConfig<OpportunityInfoCsvImport>(errors));
+      csv.Context.TypeConverterOptionsCache.GetOptions<string>().NullValues.Add(string.Empty);
 
       // Validate header before reading data rows
       // Stop if errors — prevents invalid column-to-property mapping


### PR DESCRIPTION
…ssing message

- Configured CsvHelper to treat empty string values as null for string properties
- Updated HeaderMissing error message to clearly indicate that the first row may be a record or incorrectly formatted