### PR TITLE
[YOMA-942] Update opportunity status handling

### DIFF
--- a/src/api/src/application/Yoma.Core.Api/Controllers/OpportunityController.cs
+++ b/src/api/src/application/Yoma.Core.Api/Controllers/OpportunityController.cs
@@ -448,7 +448,7 @@ namespace Yoma.Core.Api.Controllers
       return StatusCode((int)HttpStatusCode.OK, result);
     }
 
-    [SwaggerOperation(Summary = "Update opportunity status (Active / Inactive / Deleted)")]
+    [SwaggerOperation(Summary = "Update opportunity status (Active / Inactive / Deleted [Archived])")]
     [HttpPatch("{id}/{status}")]
     [ProducesResponseType(typeof(Opportunity), (int)HttpStatusCode.OK)]
     [Authorize(Roles = $"{Constants.Role_Admin}, {Constants.Role_OrganizationAdmin}")]

--- a/src/api/src/domain/Yoma.Core.Domain/Core/Extensions/EnumExtensions.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Core/Extensions/EnumExtensions.cs
@@ -43,7 +43,7 @@ namespace Yoma.Core.Domain.Core.Extensions
       if (string.IsNullOrEmpty(separator))
         throw new ArgumentException("Separator cannot be null or empty", nameof(separator));
 
-      return string.Join(separator, values.Select(v => v.ToString()));
+      return string.Join(separator, values.Select(v => v.ToDescription()));
     }
   }
 }

--- a/src/api/src/domain/Yoma.Core.Domain/Entity/Services/OrganizationService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Entity/Services/OrganizationService.cs
@@ -24,7 +24,6 @@ using Yoma.Core.Domain.Entity.Models;
 using Yoma.Core.Domain.Entity.Validators;
 using Yoma.Core.Domain.IdentityProvider.Extensions;
 using Yoma.Core.Domain.IdentityProvider.Interfaces;
-using Yoma.Core.Domain.Opportunity;
 using Yoma.Core.Domain.SSI.Interfaces;
 
 namespace Yoma.Core.Domain.Entity.Services
@@ -675,7 +674,7 @@ namespace Yoma.Core.Domain.Entity.Services
             break;
 
           default:
-            throw new ArgumentOutOfRangeException(nameof(request), $"{nameof(Status)} of '{request.Status}' not supported");
+            throw new ArgumentOutOfRangeException(nameof(request), $"{nameof(OrganizationStatus)} of '{request.Status}' not supported");
         }
 
         var statusId = _organizationStatusService.GetByName(request.Status.ToString()).Id;

--- a/src/api/src/domain/Yoma.Core.Domain/Marketplace/Services/StoreAccessControlRuleService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Marketplace/Services/StoreAccessControlRuleService.cs
@@ -18,7 +18,6 @@ using Yoma.Core.Domain.Marketplace.Models;
 using Yoma.Core.Domain.Marketplace.Validators;
 using Yoma.Core.Domain.MyOpportunity.Interfaces;
 using Yoma.Core.Domain.MyOpportunity.Models;
-using Yoma.Core.Domain.Opportunity;
 using Yoma.Core.Domain.Opportunity.Extensions;
 using Yoma.Core.Domain.Opportunity.Interfaces;
 
@@ -438,7 +437,7 @@ namespace Yoma.Core.Domain.Marketplace.Services
           break;
 
         default:
-          throw new ArgumentOutOfRangeException(nameof(status), $"{nameof(Status)} of '{status}' not supported");
+          throw new ArgumentOutOfRangeException(nameof(status), $"{nameof(StoreAccessControlRuleStatus)} of '{status}' not supported");
       }
 
       var statusId = _storeAccessControlRuleStatusService.GetByName(status.ToString()).Id;

--- a/src/api/src/domain/Yoma.Core.Domain/MyOpportunity/Services/MyOpportunityService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/MyOpportunity/Services/MyOpportunityService.cs
@@ -1444,7 +1444,7 @@ namespace Yoma.Core.Domain.MyOpportunity.Services
         reasons.Add("it has not been published");
 
       if (opportunity.Status != Status.Active)
-        reasons.Add($"its status is '{opportunity.Status}'");
+        reasons.Add($"its status is '{opportunity.Status.ToDescription()}'");
 
       if (opportunity.DateStart > DateTimeOffset.UtcNow)
         reasons.Add($"it has not yet started (start date: {opportunity.DateStart:yyyy-MM-dd})");

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Enumerations.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Enumerations.cs
@@ -1,8 +1,11 @@
+using System.ComponentModel;
+
 namespace Yoma.Core.Domain.Opportunity
 {
   public enum Status
   {
     Active, //flagged as expired provided ended (notified)
+    [Description("Archived")]
     Deleted,
     Expired, //flagged as deleted if expired and not modified for x days
     Inactive, //customer request: exclude Inactive from auto-deletion. Only Expired opportunities will be auto-deleted. Inactive will remain Inactive indefinitely until manually handled; flagged as deleted if inactive and not modified for x days

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Events/OpportunityEventHandler.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Events/OpportunityEventHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Yoma.Core.Domain.Core;
+using Yoma.Core.Domain.Core.Extensions;
 using Yoma.Core.Domain.PartnerSharing.Interfaces;
 using Yoma.Core.Domain.PartnerSharing.Services;
 
@@ -33,14 +34,14 @@ namespace Yoma.Core.Domain.Opportunity.Events
             //only scheduled for active opportunities
             if (!SharingService.Statuses_Opportunity_Creatable.Contains(notification.Entity.Status))
             {
-              _logger.LogInformation("Scheduling of partner sharing creation skipped for opportunity with id {id} and status {status}", notification.Entity.Id, notification.Entity.Status);
+              _logger.LogInformation("Scheduling of partner sharing creation skipped for opportunity with id {id} and status {status}", notification.Entity.Id, notification.Entity.Status.ToDescription());
               break;
             }
 
             //provide organization is active
             if (notification.Entity.OrganizationStatus != Entity.OrganizationStatus.Active)
             {
-              _logger.LogInformation("Scheduling of partner sharing creation skipped for opportunity with id {id} and status {status}: Organization status {orgStatus}", notification.Entity.Id, notification.Entity.Status, notification.Entity.OrganizationStatus);
+              _logger.LogInformation("Scheduling of partner sharing creation skipped for opportunity with id {id} and status {status}: Organization status {orgStatus}", notification.Entity.Id, notification.Entity.Status.ToDescription(), notification.Entity.OrganizationStatus);
               break;
             }
 
@@ -51,7 +52,7 @@ namespace Yoma.Core.Domain.Opportunity.Events
           case EventType.Update:
             if (!SharingService.Statuses_Opportunity_Updatable.Contains(notification.Entity.Status))
             {
-              _logger.LogInformation("Scheduling of partner sharing update skipped for opportunity with id {id} and status {status}", notification.Entity.Id, notification.Entity.Status);
+              _logger.LogInformation("Scheduling of partner sharing update skipped for opportunity with id {id} and status {status}", notification.Entity.Id, notification.Entity.Status.ToDescription());
               break;
             }
 
@@ -63,7 +64,7 @@ namespace Yoma.Core.Domain.Opportunity.Events
           case EventType.Delete:
             if (!SharingService.Statuses_Opportunity_CanDelete.Contains(notification.Entity.Status))
             {
-              _logger.LogInformation("Scheduling of partner sharing deletion skipped for opportunity with id {id} and status {status}", notification.Entity.Id, notification.Entity.Status);
+              _logger.LogInformation("Scheduling of partner sharing deletion skipped for opportunity with id {id} and status {status}", notification.Entity.Id, notification.Entity.Status.ToDescription());
               break;
             }
 
@@ -73,14 +74,14 @@ namespace Yoma.Core.Domain.Opportunity.Events
               case Status.Inactive:
               case Status.Expired:
                 if (notification.Entity.OrganizationStatus != Entity.OrganizationStatus.Deleted)
-                  throw new InvalidOperationException($"Event {notification.EventType}: Opportunity with status {notification.Entity.Status} must be associated with a deleted organization");
+                  throw new InvalidOperationException($"Event {notification.EventType}: Opportunity with status {notification.Entity.Status.ToDescription()} must be associated with a deleted organization");
                 break;
 
               case Status.Deleted:
                 break;
 
               default:
-                throw new InvalidOperationException($"{nameof(Status)} of '{notification.Entity.Status}' not supported");
+                throw new InvalidOperationException($"{nameof(Status)} of '{notification.Entity.Status.ToDescription()}' not supported");
             }
 
             await _sharingService.ScheduleDelete(PartnerSharing.EntityType.Opportunity, notification.Entity.Id);

--- a/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Opportunity/Services/OpportunityService.cs
@@ -1455,7 +1455,7 @@ namespace Yoma.Core.Domain.Opportunity.Services
           reasons.Add("it has not been published");
 
         if (opportunity.Status != Status.Active)
-          reasons.Add($"its status is '{opportunity.Status}'");
+          reasons.Add($"its status is '{opportunity.Status.ToDescription()}'");
 
         if (opportunity.DateStart > DateTimeOffset.UtcNow)
           reasons.Add($"it has not yet started (start date: {opportunity.DateStart:yyyy-MM-dd})");
@@ -1575,7 +1575,7 @@ namespace Yoma.Core.Domain.Opportunity.Services
         case Status.Active:
           if (result.Status == Status.Active) return result;
           if (!Statuses_Activatable.Contains(result.Status))
-            throw new ValidationException($"{nameof(Models.Opportunity)} can not be activated (current status '{result.Status}'). Required state '{Statuses_Activatable.JoinNames()}'");
+            throw new ValidationException($"{nameof(Models.Opportunity)} can not be activated (current status '{result.Status.ToDescription()}'). Required state '{Statuses_Activatable.JoinNames()}'");
 
           //ensure DateEnd was updated for re-activation of previously expired opportunities
           if (result.DateEnd.HasValue && result.DateEnd.Value <= DateTimeOffset.UtcNow)
@@ -1587,7 +1587,7 @@ namespace Yoma.Core.Domain.Opportunity.Services
         case Status.Inactive:
           if (result.Status == Status.Inactive) return result;
           if (!Statuses_DeActivatable.Contains(result.Status))
-            throw new ValidationException($"{nameof(Models.Opportunity)} can not be deactivated (current status '{result.Status}'). Required state '{Statuses_DeActivatable.JoinNames()}'");
+            throw new ValidationException($"{nameof(Models.Opportunity)} can not be deactivated (current status '{result.Status.ToDescription()}'). Required state '{Statuses_DeActivatable.JoinNames()}'");
 
           eventType = EventType.Update;
           break;
@@ -1595,13 +1595,13 @@ namespace Yoma.Core.Domain.Opportunity.Services
         case Status.Deleted:
           if (result.Status == Status.Deleted) return result;
           if (!Statuses_CanDelete.Contains(result.Status))
-            throw new ValidationException($"{nameof(Models.Opportunity)} can not be deleted (current status '{result.Status}'). Required state '{Statuses_CanDelete.JoinNames()}'");
+            throw new ValidationException($"{nameof(Models.Opportunity)} can not be deleted (current status '{result.Status.ToDescription()}'). Required state '{Statuses_CanDelete.JoinNames()}'");
 
           eventType = EventType.Delete;
           break;
 
         default:
-          throw new ArgumentOutOfRangeException(nameof(status), $"{nameof(Status)} of '{status}' not supported");
+          throw new ArgumentOutOfRangeException(nameof(status), $"{nameof(Status)} of '{status.ToDescription()}' not supported");
       }
 
       var statusId = _opportunityStatusService.GetByName(status.ToString()).Id;
@@ -1985,7 +1985,7 @@ namespace Yoma.Core.Domain.Opportunity.Services
     private static void AssertUpdatable(Models.Opportunity opportunity)
     {
       if (!Statuses_Updatable.Contains(opportunity.Status))
-        throw new ValidationException($"{nameof(Models.Opportunity)} can no longer be updated (current status '{opportunity.Status}'). Required state '{Statuses_Updatable.JoinNames()}'");
+        throw new ValidationException($"{nameof(Models.Opportunity)} can no longer be updated (current status '{opportunity.Status.ToDescription()}'). Required state '{Statuses_Updatable.JoinNames()}'");
     }
 
     private async Task AssertUpdatablePartnerSharing(OpportunityRequestUpdate request, Models.Opportunity opportunityCurrent)

--- a/src/api/src/domain/Yoma.Core.Domain/PartnerSharing/Services/SharingBackgroundService.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/PartnerSharing/Services/SharingBackgroundService.cs
@@ -122,7 +122,7 @@ namespace Yoma.Core.Domain.PartnerSharing.Services
                       {
                         var reason = opportunity.OrganizationStatus != OrganizationStatus.Active
                           ? $"Associated organization is no longer '{OrganizationStatus.Active}'"
-                          : $"Opportunity status of '{SharingService.Statuses_Opportunity_Creatable.JoinNames()}' expected. Current status '{opportunity.Status}'";
+                          : $"Opportunity status of '{SharingService.Statuses_Opportunity_Creatable.JoinNames()}' expected. Current status '{opportunity.Status.ToDescription()}'";
 
                         _logger.LogInformation("Action '{action}': Aborting for '{entityType}' and item with id '{id}'. {reason}", action, item.EntityType, item.Id, reason);
 
@@ -156,7 +156,7 @@ namespace Yoma.Core.Domain.PartnerSharing.Services
 
                       //scheduling failsafe post implicit adjustment
                       if (!SharingService.Statuses_Opportunity_Updatable.Contains(opportunity.Status))
-                        throw new InvalidOperationException($"Action '{action}': Opportunity status of '{SharingService.Statuses_Opportunity_Updatable.JoinNames()}' expected. Current status '{opportunity.Status}'");
+                        throw new InvalidOperationException($"Action '{action}': Opportunity status of '{SharingService.Statuses_Opportunity_Updatable.JoinNames()}' expected. Current status '{opportunity.Status.ToDescription()}'");
 
                       request.ExternalId = item.EntityExternalId;
                       await sharingProviderClient.UpdateOpportunity(request);
@@ -176,7 +176,7 @@ namespace Yoma.Core.Domain.PartnerSharing.Services
 
                       //scheduling failsafe
                       if (!SharingService.Statuses_Opportunity_CanDelete.Contains(opportunity.Status))
-                        throw new InvalidOperationException($"Action '{action}': Opportunity status of '{SharingService.Statuses_Opportunity_CanDelete.JoinNames()}' expected. Current status '{opportunity.Status}'");
+                        throw new InvalidOperationException($"Action '{action}': Opportunity status of '{SharingService.Statuses_Opportunity_CanDelete.JoinNames()}' expected. Current status '{opportunity.Status.ToDescription()}'");
 
                       switch (opportunity.Status)
                       {
@@ -184,14 +184,14 @@ namespace Yoma.Core.Domain.PartnerSharing.Services
                         case Status.Inactive:
                         case Status.Expired:
                           if (opportunity.OrganizationStatus != OrganizationStatus.Deleted)
-                            throw new InvalidOperationException($"Processing action {action}: Opportunity with status {opportunity.Status} must be associated with a deleted organization");
+                            throw new InvalidOperationException($"Processing action {action}: Opportunity with status {opportunity.Status.ToDescription()} must be associated with a deleted organization");
                           break;
 
                         case Status.Deleted:
                           break;
 
                         default:
-                          throw new InvalidOperationException($"Opportunity status of '{opportunity.Status}' not supported");
+                          throw new InvalidOperationException($"Opportunity status of '{opportunity.Status.ToDescription()}' not supported");
                       }
 
                       await sharingProviderClient.DeleteOpportunity(item.EntityExternalId);

--- a/src/api/src/domain/Yoma.Core.Domain/Startup.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/Startup.cs
@@ -217,7 +217,7 @@ namespace Yoma.Core.Domain
         s => s.ProcessExpiration(), options.OpportunityExpirationSchedule, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
       RecurringJob.AddOrUpdate<IOpportunityBackgroundService>($"Opportunity Expiration Notifications ({OpportunityBackgroundService.Statuses_Expirable.JoinNames()} ending within {options.OpportunityExpirationNotificationIntervalInDays} days)",
         s => s.ProcessExpirationNotifications(), options.OpportunityExpirationNotificationSchedule, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
-      RecurringJob.AddOrUpdate<IOpportunityBackgroundService>($"Opportunity Deletion ({OpportunityBackgroundService.Statuses_Deletion.JoinNames()} for more than {options.OpportunityDeletionIntervalInDays} days)",
+      RecurringJob.AddOrUpdate<IOpportunityBackgroundService>($"Opportunity Deletion [Archiving] ({OpportunityBackgroundService.Statuses_Deletion.JoinNames()} for more than {options.OpportunityDeletionIntervalInDays} days)",
         s => s.ProcessDeletion(), options.OpportunityDeletionSchedule, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
 
       //partner sharing

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.SAYouth/Client/SAYouthClient.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.SAYouth/Client/SAYouthClient.cs
@@ -119,7 +119,7 @@ namespace Yoma.Core.Infrastructure.SAYouth.Client
           break;
 
         default:
-          throw new InvalidOperationException($"Invalid / unsupported opportunity status '{request.Opportunity.Status}'");
+          throw new InvalidOperationException($"Invalid / unsupported opportunity status '{request.Opportunity.Status.ToDescription()}'");
       }
 
       if (action == null) return;


### PR DESCRIPTION
- Prevent auto-deletion of Inactive opportunities (manual handling only).
- Auto-delete Expired opportunities after 180 days (6 months).
- Keep Expired opportunities visible to youth for completion/upload during grace period.
- Cosmetically rename status Deleted -> Archived across buttons, headers, labels, and validation messages.