### PR TITLE
Update Helm charts to use DIDx registry

### DIFF
--- a/helm/keycloak/Chart.lock
+++ b/helm/keycloak/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.23.0
+  repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
+  version: 2.31.4
 - name: keycloakx
   repository: https://codecentric.github.io/helm-charts
   version: 2.2.2
 - name: keycloak-config-cli
   repository: git+https://github.com/didx-xyz/keycloak-config-cli@contrib/charts?ref=init-containers&sparse=0
   version: 5.8.1-SNAPSHOT
-digest: sha256:e1b377196467a5fba185d1141331771826a4fc15b3b3f8bad3ca8d22327ee971
-generated: "2024-09-17T13:54:36.502824+02:00"
+digest: sha256:46eb9ba56d6ed1934d15125ae84cc6dcacca77ddafbb653fc21532bd1def9d63
+generated: "2025-08-26T11:08:31.720087+02:00"

--- a/helm/keycloak/Chart.yaml
+++ b/helm/keycloak/Chart.yaml
@@ -8,7 +8,7 @@ appVersion: 22.0.1
 dependencies:
   - name: common
     version: 2.x.x
-    repository: oci://registry-1.docker.io/bitnamicharts
+    repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
 
   # https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx
   - name: keycloakx

--- a/helm/yoma-api/Chart.lock
+++ b/helm/yoma-api/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.23.0
-digest: sha256:6f8a5c162a291f6586c3eff9e6c0d3ba789bf1fe356681c300c1169303e29bcf
-generated: "2024-09-17T13:54:26.85592+02:00"
+  repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
+  version: 2.31.4
+digest: sha256:8a396c4ad43162b0b71c9b42dc9b33801244b245106fe59914286fb9f4db634c
+generated: "2025-08-26T11:08:43.354448+02:00"

--- a/helm/yoma-api/Chart.yaml
+++ b/helm/yoma-api/Chart.yaml
@@ -26,4 +26,4 @@ appVersion: 3.x.x
 dependencies:
   - name: common
     version: 2.x.x
-    repository: oci://registry-1.docker.io/bitnamicharts
+    repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -67,20 +67,21 @@ releases:
     labels:
       app: postgresql-keycloak
     namespace: {{ .Values.namespace }}
-    # https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-    chart: oci://registry-1.docker.io/bitnamicharts/postgresql
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql
+    chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/postgresql
     version: 16.6.3
     installed: {{ .Values.postgresEnabled }}
     values:
       - global:
           security:
-            # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+            # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
             # https://github.com/bitnami/charts/issues/35164
             # https://github.com/bitnami/containers/issues/84600
             allowInsecureImages: true
+          imageRegistry: ghcr.io
         fullnameOverride: postgres-keycloak
         image:
-          repository: bitnamilegacy/postgresql
+          repository: didx-xyz/bitnami-oss/postgresql
         auth:
           username: keycloak
           database: keycloak
@@ -91,10 +92,10 @@ releases:
             whenDeleted: Delete
         volumePermissions:
           image:
-            repository: bitnamilegacy/os-shell
+            repository: didx-xyz/bitnami-oss/os-shell
         metrics:
           image:
-            repository: bitnamilegacy/postgres-exporter
+            repository: didx-xyz/bitnami-oss/postgres-exporter
     secrets:
       - ./helm/postgresql-keycloak/conf/{{ .Environment.Name }}/secrets.yaml
 
@@ -102,20 +103,21 @@ releases:
     labels:
       app: postgresql
     namespace: {{ .Values.namespace }}
-    # https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-    chart: oci://registry-1.docker.io/bitnamicharts/postgresql
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql
+    chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/postgresql
     version: 16.6.3
     installed: {{ .Values.postgresEnabled }}
     values:
       - global:
           security:
-            # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+            # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
             # https://github.com/bitnami/charts/issues/35164
             # https://github.com/bitnami/containers/issues/84600
             allowInsecureImages: true
+          imageRegistry: ghcr.io
         fullnameOverride: postgres-yoma
         image:
-          repository: bitnamilegacy/postgresql
+          repository: didx-xyz/bitnami-oss/postgresql
         auth:
           username: yoma
           database: yoma-dev
@@ -126,10 +128,10 @@ releases:
             whenDeleted: Delete
         volumePermissions:
           image:
-            repository: bitnamilegacy/os-shell
+            repository: didx-xyz/bitnami-oss/os-shell
         metrics:
           image:
-            repository: bitnamilegacy/postgres-exporter
+            repository: didx-xyz/bitnami-oss/postgres-exporter
     secrets:
       - ./helm/postgresql-yoma/conf/{{ .Environment.Name }}/secrets.yaml
 
@@ -137,20 +139,21 @@ releases:
     labels:
       app: valkey
     namespace: {{ .Values.namespace }}
-    # https://github.com/bitnami/charts/tree/main/bitnami/valkey
-    chart: oci://registry-1.docker.io/bitnamicharts/valkey
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
+    chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/valkey
     version: 3.0.1
     installed: {{ .Values.valkeyEnabled }}
     values:
       - global:
           security:
-            # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+            # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
             # https://github.com/bitnami/charts/issues/35164
             # https://github.com/bitnami/containers/issues/84600
             allowInsecureImages: true
+          imageRegistry: ghcr.io
         fullnameOverride: valkey
         image:
-          repository: bitnamilegacy/valkey
+          repository: didx-xyz/bitnami-oss/valkey
         architecture: standalone
         auth:
           enabled: false
@@ -165,16 +168,16 @@ releases:
           replicaCount: 0
         sentinel:
           image:
-            repository: bitnamilegacy/valkey-sentinel
+            repository: didx-xyz/bitnami-oss/valkey-sentinel
         metrics:
           image:
-            repository: bitnamilegacy/valkey-exporter
+            repository: didx-xyz/bitnami-oss/valkey-exporter
         volumePermissions:
           image:
-            repository: bitnamilegacy/os-shell
+            repository: didx-xyz/bitnami-oss/os-shell
         kubectl:
           image:
-            repository: bitnamilegacy/kubectl
+            repository: didx-xyz/bitnami-oss/kubectl
 
   - name: yoma-api
     labels:


### PR DESCRIPTION
Migrate Helm chart dependencies from public Bitnami registry to
DIDx-maintained fork at `ghcr.io/didx-xyz/bitnami-oss-charts` for
continued maintenance.

Key changes:
* Update Chart.yaml dependencies to point to DIDx registry
* Regenerate Chart.lock files with new versions and digests
* Switch PostgreSQL image from `bitnamilegacy` to DIDx registry
* Update Valkey chart and all related image repositories
* Add imageRegistry configuration for custom registry support
* Upgrade common chart dependency from 2.23.0 to 2.31.4
* Update documentation references to DIDx repository

This ensures consistency across all components while maintaining
compatibility with existing configurations.