### PR TITLE
fix: add API key header for ZLTO wallet healthcheck

### DIFF
--- a/src/api/src/application/Yoma.Core.Api/Yoma.Core.Api.csproj
+++ b/src/api/src/application/Yoma.Core.Api/Yoma.Core.Api.csproj
@@ -24,10 +24,10 @@
 	<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
 	<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
 	<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.4" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.4" />
-	<PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="9.0.4" />
+	<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.5" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.5" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.5" />
+	<PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="9.0.5" />
 	<PackageReference Include="System.Text.Encodings.Web" Version="9.0.9" />
   </ItemGroup>
 

--- a/src/api/src/domain/Yoma.Core.Domain/Yoma.Core.Domain.csproj
+++ b/src/api/src/domain/Yoma.Core.Domain/Yoma.Core.Domain.csproj
@@ -39,15 +39,15 @@
     <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
     <PackageReference Include="Hangfire.Core" Version="1.8.21" />
-    <PackageReference Include="libphonenumber-csharp" Version="9.0.14" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.15" />
     <PackageReference Include="MediatR" Version="13.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NSwag.Annotations" Version="14.6.0" />
+    <PackageReference Include="NSwag.Annotations" Version="14.6.1" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="5.15.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.9.17" />
+    <PackageReference Include="StackExchange.Redis" Version="2.9.25" />
   </ItemGroup>
 
 </Project>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.AmazonS3/Yoma.Core.Infrastructure.AmazonS3.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.AmazonS3/Yoma.Core.Infrastructure.AmazonS3.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.1" />
-	<PackageReference Include="AWSSDK.S3" Version="4.0.7.4" />
+	<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.3" />
+	<PackageReference Include="AWSSDK.S3" Version="4.0.7.6" />
 	<PackageReference Include="tusdotnet" Version="2.10.0" />
 	<PackageReference Include="tusdotnet.Stores.S3" Version="2.1.0" />
   </ItemGroup>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Twillio/Yoma.Core.Infrastructure.Twilio.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Twillio/Yoma.Core.Infrastructure.Twilio.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libphonenumber-csharp" Version="9.0.14" />
-    <PackageReference Include="Twilio" Version="7.13.1" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.15" />
+    <PackageReference Include="Twilio" Version="7.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Zlto/HealthCheck.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Zlto/HealthCheck.cs
@@ -1,3 +1,4 @@
+using Flurl;
 using Flurl.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -42,7 +43,8 @@ namespace Yoma.Core.Infrastructure.Zlto
       {
         try
         {
-          await e.Url.GetAsync(cancellationToken: cancellationToken).EnsureSuccessStatusCodeAsync();
+          var url = new Url(e.Url);
+          await url.WithAuthHeader(GetAuthHeaderApiKey()).GetAsync(cancellationToken: cancellationToken).EnsureSuccessStatusCodeAsync();
           return (e.Name, Failure: (string?)null);
         }
         catch (HttpClientException ex)
@@ -65,6 +67,13 @@ namespace Yoma.Core.Infrastructure.Zlto
       if (failures.Length == 0) return HealthCheckResult.Healthy($"{ZltoOptions.Section} endpoints: OK");
 
       return HealthCheckResult.Unhealthy($"{ZltoOptions.Section} endpoints failing: {string.Join(", ", failures)}");
+    }
+    #endregion
+
+    #region Private Members
+    private KeyValuePair<string, string> GetAuthHeaderApiKey()
+    {
+      return new KeyValuePair<string, string>(_options.ApiKeyHeaderName, _options.ApiKey);
     }
     #endregion
   }

--- a/src/api/src/test/Yoma.Core.Test/Yoma.Core.Test.csproj
+++ b/src/api/src/test/Yoma.Core.Test/Yoma.Core.Test.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Wallet service returns {"detail":"Not authenticated"} without the header. Including the `Zlto-API-Key` resolves the issue in prod, while other ZLTO services remain unaffected.