### PR TITLE
feat: Add IXO SSO client to Keycloak

### DIFF
--- a/helm/keycloak/conf/dev/values.yaml
+++ b/helm/keycloak/conf/dev/values.yaml
@@ -90,6 +90,8 @@ config-cli:
     CLIENT_GOODWALL_URL_REDIRECT: goodwallauth://yomaredirect
     CLIENT_IIASA_URL: https://localhost:44345
     CLIENT_IIASA_URL_REDIRECT: https://localhost:44345/signin-yoma-oidc
+    CLIENT_IXO_URL: https://jambo.test.yoma.impacts.exchange
+    CLIENT_IXO_URL_REDIRECT: https://jambo.test.yoma.impacts.exchange/auth/passkey
     CLIENT_MINI_SASS_URL: http://localhost:5000
     CLIENT_MINI_SASS_URL_REDIRECT: http://localhost:5000/authentication/api/yoma/callback
     GOOGLE_CLIENT_ID: 1088325631106-bujeaidsr9a94fqq92qkpcnn1aa73phv.apps.googleusercontent.com

--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -100,6 +100,9 @@ config-cli:
     CLIENT_GOODWALL_URL_REDIRECT: goodwallauth://yomaredirect
     CLIENT_IIASA_URL: https://geoqauth.main.geo-wiki.org
     CLIENT_IIASA_URL_REDIRECT: https://geoqauth.main.geo-wiki.org/signin-yoma-oidc
+    CLIENT_IXO_ENABLED: "false"
+    CLIENT_IXO_URL: https://jambo.yoma.impacts.exchange
+    CLIENT_IXO_URL_REDIRECT: https://jambo.yoma.impacts.exchange/auth/passkey
     CLIENT_UNICEF_KENYA_ENABLED: "false"
     CLIENT_MINI_SASS_URL: https://minisass.org
     CLIENT_MINI_SASS_URL_REDIRECT: https://minisass.org/authentication/api/yoma/callback

--- a/helm/keycloak/conf/stage/values.yaml
+++ b/helm/keycloak/conf/stage/values.yaml
@@ -96,6 +96,8 @@ config-cli:
     CLIENT_GOODWALL_URL_REDIRECT: goodwallauth://yomaredirect
     CLIENT_IIASA_URL: https://localhost:44345
     CLIENT_IIASA_URL_REDIRECT: https://localhost:44345/signin-yoma-oidc
+    CLIENT_IXO_URL: https://jambo.test.yoma.impacts.exchange
+    CLIENT_IXO_URL_REDIRECT: https://jambo.test.yoma.impacts.exchange/auth/passkey
     CLIENT_MINI_SASS_URL: https://minisass.sta.do.kartoza.com
     CLIENT_MINI_SASS_URL_REDIRECT: https://minisass.sta.do.kartoza.com/authentication/api/yoma/callback
     GOOGLE_CLIENT_ID: 1088325631106-bujeaidsr9a94fqq92qkpcnn1aa73phv.apps.googleusercontent.com

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -414,8 +414,7 @@ keycloak:
     maxUnavailable: 1
     # minAvailable: 1
 
-  database:
-    {}
+  database: {}
     # existingSecret: keycloak-db
     # existingSecretKey: password
     # vendor: postgres
@@ -483,6 +482,7 @@ config-cli:
     CLIENT_ATINGI_ENABLED: "true"
     CLIENT_GOODWALL_ENABLED: "true"
     CLIENT_IIASA_ENABLED: "true"
+    CLIENT_IXO_ENABLED: "true"
     CLIENT_MAZA_APP_ENABLED: "true"
     CLIENT_UNICEF_KENYA_ENABLED: "true"
     CLIENT_MINI_SASS_ENABLED: "true"

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -209,6 +209,9 @@ services:
       CLIENT_IIASA_SECRET: superSecretIIASAClientSecret
       CLIENT_IIASA_URL: https://localhost:44345
       CLIENT_IIASA_URL_REDIRECT: https://localhost:44345/signin-yoma-oidc
+      CLIENT_IXO_ENABLED: "true"
+      CLIENT_IXO_URL: https://jambo.test.yoma.impacts.exchange
+      CLIENT_IXO_URL_REDIRECT: https://jambo.test.yoma.impacts.exchange/auth/passkey
       CLIENT_MAZA_APP_ENABLED: "true"
       CLIENT_MAZA_APP_SECRET: superSecretMazaAppClientSecret
       CLIENT_UNICEF_KENYA_ENABLED: "true"

--- a/src/keycloak/exports/01-yoma-realm.yaml
+++ b/src/keycloak/exports/01-yoma-realm.yaml
@@ -805,6 +805,60 @@ clients:
       - address
       - phone
       - microprofile-jwt
+  - id: 045a13ad-3d8e-4d2b-ac96-5a8d9567dadf
+    clientId: ixo
+    name: ixo
+    description: IXO SSO Partner (public client)
+    rootUrl: $(env:CLIENT_IXO_URL)
+    adminUrl: $(env:CLIENT_IXO_URL)
+    baseUrl: $(env:CLIENT_IXO_URL)
+    surrogateAuthRequired: false
+    enabled: $(env:CLIENT_IXO_ENABLED)
+    alwaysDisplayInConsole: false
+    clientAuthenticatorType: client-secret
+    redirectUris:
+      - /*
+      - $(env:CLIENT_IXO_URL_REDIRECT)
+      - $(env:CLIENT_IXO_URL_REDIRECT)/*
+    webOrigins:
+      - /*
+      - $(env:CLIENT_IXO_URL)
+      - $(env:CLIENT_IXO_URL)/*
+    notBefore: 0
+    bearerOnly: false
+    consentRequired: false
+    standardFlowEnabled: true
+    implicitFlowEnabled: false
+    directAccessGrantsEnabled: false
+    serviceAccountsEnabled: false
+    publicClient: true
+    frontchannelLogout: true
+    protocol: openid-connect
+    attributes:
+      post.logout.redirect.uris: $(env:CLIENT_IXO_URL)/*
+      oidc.ciba.grant.enabled: "false"
+      backchannel.logout.session.required: "true"
+      standard.token.exchange.enabled: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      dpop.bound.access.tokens: "false"
+      use.refresh.tokens: "true"
+    authenticationFlowBindingOverrides: {}
+    fullScopeAllowed: true
+    nodeReRegistrationTimeout: -1
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - roles
+      - offline_access
+      - profile
+      - yoma-api
+      - audience_scope
+      - email
+    optionalClientScopes:
+      - address
+      - phone
+      - microprofile-jwt
   - id: ff74b115-0fdb-4a94-9e05-7459601ae7ee
     clientId: maza-app
     name: maza-app
@@ -1159,7 +1213,7 @@ clientScopes:
           jsonType.label: long
   - id: 6079a599-eae4-4d92-8178-8904dcdc1ec2
     name: phone
-    description: 'OpenID Connect built-in scope: phone'
+    description: "OpenID Connect built-in scope: phone"
     protocol: openid-connect
     attributes:
       include.in.token.scope: "true"
@@ -1275,7 +1329,7 @@ clientScopes:
           userinfo.token.claim: "true"
   - id: 03ea262c-9037-43bf-9a7a-8acb003ba8be
     name: offline_access
-    description: 'OpenID Connect built-in scope: offline_access'
+    description: "OpenID Connect built-in scope: offline_access"
     protocol: openid-connect
     attributes:
       consent.screen.text: ${offlineAccessScopeConsentText}
@@ -1342,7 +1396,7 @@ clientScopes:
           access.token.claim: "true"
   - id: 0f08cea0-1ab2-45af-b5fe-dbd79f00a79a
     name: address
-    description: 'OpenID Connect built-in scope: address'
+    description: "OpenID Connect built-in scope: address"
     protocol: openid-connect
     attributes:
       include.in.token.scope: "true"
@@ -1410,7 +1464,7 @@ clientScopes:
           jsonType.label: String
   - id: 37ac273c-3e98-4e18-8f5c-a68843ffa16b
     name: email
-    description: 'OpenID Connect built-in scope: email'
+    description: "OpenID Connect built-in scope: email"
     protocol: openid-connect
     attributes:
       include.in.token.scope: "true"
@@ -1443,7 +1497,7 @@ clientScopes:
           userinfo.token.claim: "true"
   - id: c394b5bf-bf78-4bd6-905b-cf7fadca2cad
     name: profile
-    description: 'OpenID Connect built-in scope: profile'
+    description: "OpenID Connect built-in scope: profile"
     protocol: openid-connect
     attributes:
       include.in.token.scope: "true"
@@ -2338,12 +2392,10 @@ authenticationFlows:
         authenticatorFlow: false
         requirement: REQUIRED
         priority: 10
-        authenticatorFlow: false
         userSetupAllowed: false
       - authenticatorFlow: true
         requirement: CONDITIONAL
         priority: 20
-        authenticatorFlow: true
         flowAlias: First broker login - Conditional OTP
         userSetupAllowed: false
   - id: 1a8b8a2c-4b5e-4e9a-9b8d-0b7f0d5e9f01


### PR DESCRIPTION
## Summary

* Adds the `ixo` public OIDC client to the Keycloak realm export with passkey redirect URI
* Wires up `CLIENT_IXO_ENABLED`, `CLIENT_IXO_URL`, and `CLIENT_IXO_URL_REDIRECT` env vars across dev, stage, prod, and docker-compose
* Client is enabled by default in dev/stage; disabled in prod until ready

---

Closes [YOM-1109](https://linear.app/didx/issue/YOM-1109/create-ixo-sso-client)