### PR TITLE
fix: resolve OpportunityCategory delete failure caused by entity mism…

### DIFF
--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Opportunity/Repositories/OpportunityCategoryRepository.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Opportunity/Repositories/OpportunityCategoryRepository.cs
@@ -60,8 +60,8 @@ namespace Yoma.Core.Infrastructure.Database.Opportunity.Repositories
 
     public async Task Delete(OpportunityCategory item)
     {
-      var entity = _context.OpportunityCategory.Where(o => o.Id == item.Id).SingleOrDefault() ?? throw new ArgumentOutOfRangeException(nameof(item), $"{nameof(OpportunityCategory)} with id '{item.Id}' does not exist");
-      _context.OpportunityCategory.Remove(entity);
+      var entity = _context.OpportunityCategories.Where(o => o.Id == item.Id).SingleOrDefault() ?? throw new ArgumentOutOfRangeException(nameof(item), $"{nameof(OpportunityCategory)} with id '{item.Id}' does not exist");
+      _context.OpportunityCategories.Remove(entity);
       await _context.SaveChangesAsync();
     }
     #endregion


### PR DESCRIPTION
…atch

Delete operation was using the wrong entity mapping when resolving the OpportunityCategory record. This caused valid records to fail lookup and throw ArgumentOutOfRangeException during category removal. Updated the repository usage to align with the correct OpportunityCategories entity.