### PR TITLE
fix(helm): Traefik kubernetesIngressNginx compatibility fixes

### DIFF
--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -8,7 +8,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
     className: nginx-internal
     rules:
       - host: example.com
@@ -22,7 +21,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
     className: nginx-internal
     rules:
       - host: auth.example.com
@@ -33,7 +31,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 128k
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 8 128k;
     className: nginx-external
     rules:
       - host: "{{ .Values.keycloak.ingressDomain }}"

--- a/helm/yoma-api/conf/dev/values.yaml
+++ b/helm/yoma-api/conf/dev/values.yaml
@@ -20,9 +20,9 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
       nginx.ingress.kubernetes.io/cors-allow-origin: "https://dev.yoma.world"
-      nginx.ingress.kubernetes.io/server-snippet: |-
-        location /hangfire {
-          deny all;
+      nginx.ingress.kubernetes.io/server-snippet: |
+        if ($request_uri ~* "^/hangfire") {
+          return 403;
         }
     rules:
       - host: v3api.dev.yoma.world

--- a/helm/yoma-api/conf/prod/values.yaml
+++ b/helm/yoma-api/conf/prod/values.yaml
@@ -21,9 +21,9 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
       nginx.ingress.kubernetes.io/cors-allow-origin: "https://yoma.world"
-      nginx.ingress.kubernetes.io/server-snippet: |-
-        location /hangfire {
-          deny all;
+      nginx.ingress.kubernetes.io/server-snippet: |
+        if ($request_uri ~* "^/hangfire") {
+          return 403;
         }
     rules:
       - host: api.yoma.world

--- a/helm/yoma-api/conf/stage/values.yaml
+++ b/helm/yoma-api/conf/stage/values.yaml
@@ -21,9 +21,9 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
       nginx.ingress.kubernetes.io/cors-allow-origin: "https://stage.yoma.world,https://yoma-six.vercel.app"
-      nginx.ingress.kubernetes.io/server-snippet: |-
-        location /hangfire {
-          deny all;
+      nginx.ingress.kubernetes.io/server-snippet: |
+        if ($request_uri ~* "^/hangfire") {
+          return 403;
         }
     rules:
       - host: v3api.stage.yoma.world

--- a/helm/yoma-web/conf/dev/values.yaml
+++ b/helm/yoma-web/conf/dev/values.yaml
@@ -18,6 +18,5 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: dev.yoma.world

--- a/helm/yoma-web/conf/prod/values.yaml
+++ b/helm/yoma-web/conf/prod/values.yaml
@@ -18,7 +18,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.world') {
           rewrite ^ https://yoma.world$request_uri permanent;
@@ -50,7 +49,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
       nginx.ingress.kubernetes.io/configuration-snippet: |-
         if ($host = 'app.yoma.world') {
           rewrite ^ https://yoma.world$request_uri permanent;

--- a/helm/yoma-web/conf/stage/values.yaml
+++ b/helm/yoma-web/conf/stage/values.yaml
@@ -18,7 +18,6 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: stage.yoma.world
   external:
@@ -28,6 +27,5 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 512k
       nginx.ingress.kubernetes.io/proxy-busy-buffers-size: 512k
-      nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 512k;
     rules:
       - host: stage.yoma.world


### PR DESCRIPTION
## Summary

Pre-conditions for migrating `nginx-internal` and `nginx-external` IngressClass traffic from Ingress NGINX to Traefik 3.7, using Traefik's `kubernetesIngressNginx` provider.

- **yoma-api** (dev/stage/prod): replace `server-snippet: location /hangfire { deny all; }` with `if ($request_uri ~* "^/hangfire") { return 403; }` — `location` blocks and `deny` are not translated by Traefik 3.7; `if` + `return` are in the supported directive set and produce identical 403 behaviour under NGINX
- **keycloak** (dev/stage/prod): remove `server-snippet: large_client_header_buffers 8 128k;` — not a supported Traefik snippet directive; safe to drop because Traefik (Go `net/http`) defaults to 1MB for request headers vs NGINX's 4×8k (32k) default that this was tuning
- **yoma-web** (dev/stage/prod): remove `server-snippet: large_client_header_buffers 4 512k;` — same rationale as Keycloak