### PR TITLE
feat: remove picture popup / add user initials avatar / remove education from user profile

### DIFF
--- a/src/web/src/components/Global.tsx
+++ b/src/web/src/components/Global.tsx
@@ -1070,7 +1070,6 @@ export const Global: React.FC = () => {
                   UserProfileFilterOptions.FIRSTNAME,
                   UserProfileFilterOptions.SURNAME,
                   UserProfileFilterOptions.COUNTRY,
-                  UserProfileFilterOptions.EDUCATION,
                   UserProfileFilterOptions.GENDER,
                   UserProfileFilterOptions.DATEOFBIRTH,
                 ]}

--- a/src/web/src/components/Global.tsx
+++ b/src/web/src/components/Global.tsx
@@ -43,12 +43,11 @@ import {
   screenWidthAtom,
   userProfileAtom,
 } from "~/lib/store";
+import { fetchClientEnv } from "~/lib/utils";
 import {
-  hasUserPhoto,
   isUserProfileCompleted,
   isUserSettingsConfigured,
 } from "~/lib/utils/profile";
-import { fetchClientEnv } from "~/lib/utils";
 import CustomModal from "./Common/CustomModal";
 import Suspense from "./Common/Suspense";
 import SettingsForm from "./Settings/SettingsForm";
@@ -408,7 +407,7 @@ export const Global: React.FC = () => {
       if (!userProfile) return;
 
       const skipSettings = options?.skipSettings ?? false;
-      const skipPhoto = options?.skipPhoto ?? false;
+      //const skipPhoto = options?.skipPhoto ?? false;
 
       const currentPath = routePathRef.current;
 
@@ -457,7 +456,7 @@ export const Global: React.FC = () => {
       sessionStatus,
       setUpdateProfileDialogVisible,
       setSettingsDialogVisible,
-      setPhotoUploadDialogVisible,
+      //setPhotoUploadDialogVisible,
       showRefereeReferralReminder,
     ],
   );

--- a/src/web/src/components/Global.tsx
+++ b/src/web/src/components/Global.tsx
@@ -38,6 +38,7 @@ import {
   firstActionableRefereeReferralUrlAtom,
   hasDismissedRefereeWelcomeModalAtom,
   hasShownRefereePendingToastAtom,
+  hasSkippedSettingsDialogAtom,
   rumConsentAtom,
   screenWidthAtom,
   userProfileAtom,
@@ -86,6 +87,9 @@ export const Global: React.FC = () => {
   const setHasDismissedRefereeWelcomeModal = useSetAtom(
     hasDismissedRefereeWelcomeModalAtom,
   );
+  const [hasSkippedSettingsDialog, setHasSkippedSettingsDialog] = useAtom(
+    hasSkippedSettingsDialogAtom,
+  );
   const setScreenWidthAtom = useSetAtom(screenWidthAtom);
 
   const [loginDialogVisible, setLoginDialogVisible] = useState(false);
@@ -109,10 +113,8 @@ export const Global: React.FC = () => {
   const currentLanguage = useAtomValue(currentLanguageAtom);
 
   const anyBlockingModalOpen =
-    loginDialogVisible ||
-    updateProfileDialogVisible ||
-    settingsDialogVisible ||
-    photoUploadDialogVisible;
+    loginDialogVisible || updateProfileDialogVisible || settingsDialogVisible;
+  // || photoUploadDialogVisible; // photo upload dialog disabled
 
   useEffect(() => {
     let isMounted = true;
@@ -423,12 +425,16 @@ export const Global: React.FC = () => {
       if (!isUserProfileCompleted(userProfile)) {
         // show update profile dialog
         setUpdateProfileDialogVisible(true);
-      } else if (!skipSettings && !isUserSettingsConfigured(userProfile)) {
+      } else if (
+        !skipSettings &&
+        !hasSkippedSettingsDialog &&
+        !isUserSettingsConfigured(userProfile)
+      ) {
         // show settings dialog
         setSettingsDialogVisible(true);
-      } else if (!skipPhoto && !hasUserPhoto(userProfile)) {
-        // show photo upload dialog
-        setPhotoUploadDialogVisible(true);
+        // } else if (!skipPhoto && !hasUserPhoto(userProfile)) {
+        //   // show photo upload dialog (disabled)
+        //   setPhotoUploadDialogVisible(true);
       } else if (
         referralsFlagResolved &&
         referralsEnabled &&
@@ -445,6 +451,7 @@ export const Global: React.FC = () => {
     [
       actionableRefereeReferral,
       hasShownRefereePendingToast,
+      hasSkippedSettingsDialog,
       referralsEnabled,
       referralsFlagResolved,
       sessionStatus,
@@ -552,12 +559,14 @@ export const Global: React.FC = () => {
       postLoginChecksTriggeredRef.current = false;
       setHasShownRefereePendingToast(false);
       setHasDismissedRefereeWelcomeModal(false);
+      setHasSkippedSettingsDialog(false);
       setFirstActionableRefereeReferralUrl(null);
     }
   }, [
     sessionStatus,
     setHasDismissedRefereeWelcomeModal,
     setHasShownRefereePendingToast,
+    setHasSkippedSettingsDialog,
     setFirstActionableRefereeReferralUrl,
   ]);
 
@@ -1110,6 +1119,7 @@ export const Global: React.FC = () => {
               type="button"
               className="hover:text-green text-sm text-black underline"
               onClick={() => {
+                setHasSkippedSettingsDialog(true);
                 setSettingsDialogVisible(false);
                 postLoginChecks(userProfile!, { skipSettings: true });
               }}
@@ -1120,73 +1130,75 @@ export const Global: React.FC = () => {
         </div>
       </CustomModal>
 
-      {/* UPLOAD PHOTO DIALOG */}
-      <CustomModal
-        isOpen={photoUploadDialogVisible}
-        shouldCloseOnOverlayClick={false}
-        onRequestClose={() => {
-          setPhotoUploadDialogVisible(false);
-        }}
-        className="md:max-h-[680px] md:w-[700px]"
-      >
-        <div className="flex h-full flex-col gap-2 overflow-y-auto">
-          <div className="bg-theme flex h-16 flex-row p-8 shadow-lg"></div>
-          <div className="flex flex-col items-center justify-center gap-4 px-6 pb-8 text-center md:px-12">
-            <div className="border-purple-dark -mt-8 flex items-center justify-center rounded-full bg-white p-2 shadow-lg">
-              <FcCamera className="size-8 md:size-10" />
-            </div>
+      {/* UPLOAD PHOTO DIALOG (disabled) */}
+      {false && (
+        <CustomModal
+          isOpen={photoUploadDialogVisible}
+          shouldCloseOnOverlayClick={false}
+          onRequestClose={() => {
+            setPhotoUploadDialogVisible(false);
+          }}
+          className="md:max-h-[680px] md:w-[700px]"
+        >
+          <div className="flex h-full flex-col gap-2 overflow-y-auto">
+            <div className="bg-theme flex h-16 flex-row p-8 shadow-lg"></div>
+            <div className="flex flex-col items-center justify-center gap-4 px-6 pb-8 text-center md:px-12">
+              <div className="border-purple-dark -mt-8 flex items-center justify-center rounded-full bg-white p-2 shadow-lg">
+                <FcCamera className="size-8 md:size-10" />
+              </div>
 
-            <div className="flex flex-col gap-2">
-              <h4 className="text-2xl font-semibold tracking-wide">
-                Picture time!
-              </h4>
-              <h5 className="text-sm font-semibold tracking-widest">
-                Choose a profile picture
-              </h5>
-            </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-2xl font-semibold tracking-wide">
+                  Picture time!
+                </h4>
+                <h5 className="text-sm font-semibold tracking-widest">
+                  Choose a profile picture
+                </h5>
+              </div>
 
-            <div className="w-full">
-              <UserProfileForm
-                userProfile={userProfile}
-                onSubmit={async (updatedUserProfile) => {
-                  // update atom with new profile data (includes photo)
-                  setUserProfile(updatedUserProfile);
+              <div className="w-full">
+                <UserProfileForm
+                  userProfile={userProfile}
+                  onSubmit={async (updatedUserProfile) => {
+                    // update atom with new profile data (includes photo)
+                    setUserProfile(updatedUserProfile);
 
-                  // invalidate userProfile query to ensure all components get fresh data
-                  await queryClient.invalidateQueries({
-                    queryKey: ["userProfile"],
-                  });
+                    // invalidate userProfile query to ensure all components get fresh data
+                    await queryClient.invalidateQueries({
+                      queryKey: ["userProfile"],
+                    });
 
-                  // hide popup
+                    // hide popup
+                    setPhotoUploadDialogVisible(false);
+
+                    // Photo flow is the last blocker; do not reopen it when continuing checks.
+                    postLoginChecks(updatedUserProfile, {
+                      skipSettings: true,
+                      skipPhoto: true,
+                    });
+                  }}
+                  filterOptions={[UserProfileFilterOptions.LOGO]}
+                />
+              </div>
+
+              {/* skip for now link */}
+              <button
+                type="button"
+                className="hover:text-green text-sm text-black underline"
+                onClick={() => {
                   setPhotoUploadDialogVisible(false);
-
-                  // Photo flow is the last blocker; do not reopen it when continuing checks.
-                  postLoginChecks(updatedUserProfile, {
+                  postLoginChecks(userProfile!, {
                     skipSettings: true,
                     skipPhoto: true,
                   });
                 }}
-                filterOptions={[UserProfileFilterOptions.LOGO]}
-              />
+              >
+                Skip for now
+              </button>
             </div>
-
-            {/* skip for now link */}
-            <button
-              type="button"
-              className="hover:text-green text-sm text-black underline"
-              onClick={() => {
-                setPhotoUploadDialogVisible(false);
-                postLoginChecks(userProfile!, {
-                  skipSettings: true,
-                  skipPhoto: true,
-                });
-              }}
-            >
-              Skip for now
-            </button>
           </div>
-        </div>
-      </CustomModal>
+        </CustomModal>
+      )}
 
       {/* LOGIN AGAIN DIALOG */}
       <CustomModal

--- a/src/web/src/components/NavBar/UserMenu.tsx
+++ b/src/web/src/components/NavBar/UserMenu.tsx
@@ -28,6 +28,8 @@ import {
 import { fetchClientEnv } from "~/lib/utils";
 import { AvatarImage } from "../AvatarImage";
 import { Header } from "../Common/Header";
+import { UserInitialsAvatar } from "../User/UserInitialsAvatar";
+
 import Suspense from "../Common/Suspense";
 import NoRowsMessage from "../NoRowsMessage";
 import { SignOutButton } from "../SignOutButton";
@@ -155,11 +157,13 @@ export const UserMenu: React.FC = () => {
             {(activeRoleView == RoleView.User ||
               activeRoleView == RoleView.Admin) && (
               <>
-                <div className="rounded-full hover:outline hover:outline-white">
-                  <AvatarImage
-                    icon={userProfile?.photoURL ?? null}
-                    alt="User Logo"
+                <div className="rounded-full outline outline-white hover:brightness-90">
+                  <UserInitialsAvatar
+                    firstName={userProfile?.firstName}
+                    surname={userProfile?.surname}
+                    photoURL={userProfile?.photoURL}
                     size={44}
+                    alt="User Logo"
                   />
                 </div>
               </>
@@ -218,10 +222,12 @@ export const UserMenu: React.FC = () => {
                 />
 
                 <div className="relative z-10 mt-6 mr-2 overflow-hidden rounded-full shadow">
-                  <AvatarImage
-                    icon={userProfile?.photoURL}
-                    alt="User logo"
+                  <UserInitialsAvatar
+                    firstName={userProfile?.firstName}
+                    surname={userProfile?.surname}
+                    photoURL={userProfile?.photoURL}
                     size={80}
+                    alt="User logo"
                   />
                 </div>
                 <div className="w-[200px] truncate text-center text-sm font-semibold text-black md:text-base">

--- a/src/web/src/components/NavBar/UserMenu.tsx
+++ b/src/web/src/components/NavBar/UserMenu.tsx
@@ -158,13 +158,15 @@ export const UserMenu: React.FC = () => {
               activeRoleView == RoleView.Admin) && (
               <>
                 <div className="rounded-full outline outline-white hover:brightness-90">
-                  <UserInitialsAvatar
-                    firstName={userProfile?.firstName}
-                    surname={userProfile?.surname}
-                    photoURL={userProfile?.photoURL}
-                    size={44}
-                    alt="User Logo"
-                  />
+                  {userProfile && (
+                    <UserInitialsAvatar
+                      firstName={userProfile?.firstName}
+                      surname={userProfile?.surname}
+                      photoURL={userProfile?.photoURL}
+                      size={44}
+                      alt="User Logo"
+                    />
+                  )}
                 </div>
               </>
             )}
@@ -222,13 +224,15 @@ export const UserMenu: React.FC = () => {
                 />
 
                 <div className="relative z-10 mt-6 mr-2 overflow-hidden rounded-full shadow">
-                  <UserInitialsAvatar
-                    firstName={userProfile?.firstName}
-                    surname={userProfile?.surname}
-                    photoURL={userProfile?.photoURL}
-                    size={80}
-                    alt="User logo"
-                  />
+                  {userProfile && (
+                    <UserInitialsAvatar
+                      firstName={userProfile?.firstName}
+                      surname={userProfile?.surname}
+                      photoURL={userProfile?.photoURL}
+                      size={80}
+                      alt="User logo"
+                    />
+                  )}
                 </div>
                 <div className="w-[200px] truncate text-center text-sm font-semibold text-black md:text-base">
                   {session?.user?.name ?? "Settings"}

--- a/src/web/src/components/User/UserInitialsAvatar.tsx
+++ b/src/web/src/components/User/UserInitialsAvatar.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { AvatarImage } from "../AvatarImage";
+
+export const UserInitialsAvatar: React.FC<{
+  firstName?: string | null;
+  surname?: string | null;
+  photoURL?: string | null;
+  size: number;
+  alt?: string;
+}> = ({ firstName, surname, photoURL, size, alt = "User" }) => {
+  if (photoURL) {
+    return <AvatarImage icon={photoURL} alt={alt} size={size} />;
+  }
+  const initials = `${firstName ?? ""}${surname ?? ""}`;
+  let hash = 0;
+  for (let i = 0; i < initials.length; i++) {
+    hash = initials.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  const label =
+    `${firstName?.[0] ?? ""}${surname?.[0] ?? ""}`.toUpperCase() || "?";
+  return (
+    <div
+      className="flex items-center justify-center rounded-full font-semibold text-white select-none"
+      style={{
+        width: size,
+        height: size,
+        fontSize: size * 0.35,
+        backgroundColor: `hsl(${hue}, 55%, 45%)`,
+      }}
+    >
+      {label}
+    </div>
+  );
+};

--- a/src/web/src/components/User/UserProfileForm.tsx
+++ b/src/web/src/components/User/UserProfileForm.tsx
@@ -114,7 +114,7 @@ export const UserProfileForm: React.FC<{
     firstName: zod.string().min(1, "First name is required."),
     surname: zod.string().min(1, "Last name is required."),
     countryId: zod.string().min(1, "Country is required."),
-    educationId: zod.string().min(1, "Education is required."),
+    educationId: zod.string(),
     genderId: zod.string().min(1, "Gender is required."),
     dateOfBirthDay: zod.string().min(1, "Day is required."),
     dateOfBirthMonth: zod.string().min(1, "Month is required."),

--- a/src/web/src/lib/store.tsx
+++ b/src/web/src/lib/store.tsx
@@ -93,6 +93,15 @@ const hasDismissedRefereeWelcomeModalAtom = atomWithStorage<boolean>(
   { getOnInit: true },
 );
 
+// tracks whether the user has skipped the settings dialog in the current browser login session
+// reset on logout so the popup shows again on next login
+const hasSkippedSettingsDialogAtom = atomWithStorage<boolean>(
+  "hasSkippedSettingsDialog",
+  false,
+  undefined,
+  { getOnInit: true },
+);
+
 export {
   userProfileAtom,
   screenWidthAtom,
@@ -106,4 +115,5 @@ export {
   firstActionableRefereeReferralUrlAtom,
   hasShownRefereePendingToastAtom,
   hasDismissedRefereeWelcomeModalAtom,
+  hasSkippedSettingsDialogAtom,
 };

--- a/src/web/src/lib/utils/profile.ts
+++ b/src/web/src/lib/utils/profile.ts
@@ -9,17 +9,9 @@ export function isUserProfileCompleted(
 ): boolean | null {
   if (!userProfile) return null;
 
-  const { firstName, surname, countryId, educationId, genderId, dateOfBirth } =
-    userProfile;
+  const { firstName, surname, countryId, genderId, dateOfBirth } = userProfile;
 
-  if (
-    !firstName ||
-    !surname ||
-    !countryId ||
-    !educationId ||
-    !genderId ||
-    !dateOfBirth
-  ) {
+  if (!firstName || !surname || !countryId || !genderId || !dateOfBirth) {
     return false;
   }
 


### PR DESCRIPTION
YOM-1197/profile-photo-prompt-creates-registration-friction
YOM-1196/simplify-the-profile-fields-popup

Removed the post‑registration picture popup entirely.

Updated the settings popup to be session‑based, so it no longer reappears when opening new tabs or navigating around during the same login session.

Updated the user avatar logic: it now defaults to the user’s initials with a randomly assigned background colour.