### PR TITLE
fix/YOM-1199_chore-yoma-web-maintenance

### DIFF
--- a/src/web/src/lib/datadog.ts
+++ b/src/web/src/lib/datadog.ts
@@ -102,7 +102,11 @@ export const initializeDatadog = async () => {
           ? [
               {
                 match: `${env.NEXT_PUBLIC_API_BASE_URL}/`,
-                propagatorTypes: ["tracecontext"],
+                // Use "datadog" propagator (x-datadog-* headers) instead of "tracecontext"
+                // (traceparent/tracestate/baggage). The baggage header is blocked by the
+                // API's CORS policy. The backend team needs to add baggage, traceparent,
+                // tracestate to Access-Control-Allow-Headers for full W3C tracing support.
+                propagatorTypes: ["datadog"],
               },
             ]
           : [],

--- a/src/web/src/lib/react-query-config.ts
+++ b/src/web/src/lib/react-query-config.ts
@@ -2,7 +2,7 @@ export const config = {
   defaultOptions: {
     queries: {
       staleTime: 1 * 60 * 60 * 1000,
-      cacheTime: 5 * 60 * 60 * 1000,
+      gcTime: 5 * 60 * 60 * 1000,
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
- fix(datadog): update propagator type to 'datadog' for CORS compliance
- fix(react-query): rename cacheTime to gcTime for clarity