### PR TITLE
fix(web): resolve JSX.Element type errors and pin @types/minimatch

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -89,5 +89,8 @@
   },
   "engines": {
     "node": "24.x"
+  },
+  "resolutions": {
+    "@types/minimatch": "5.1.2"
   }
 }

--- a/src/web/src/components/Opportunity/OpportunityStatus.tsx
+++ b/src/web/src/components/Opportunity/OpportunityStatus.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const OpportunityStatus: React.FC<{ status: string }> = ({ status }) => {
-  function renderStatusBadge(status: string): JSX.Element | null {
+  function renderStatusBadge(status: string): React.ReactElement | null {
     switch (status) {
       case "Active":
         return (

--- a/src/web/src/components/Settings/SettingsForm.tsx
+++ b/src/web/src/components/Settings/SettingsForm.tsx
@@ -140,7 +140,7 @@ const SettingsForm: React.FC<SettingsFormProps> = ({
   const renderGroup = (
     group: SettingGroup,
     depth: number,
-  ): JSX.Element | null => {
+  ): React.ReactElement | null => {
     const visibleItems = group.items?.filter((item) => item.visible) || [];
 
     return (

--- a/src/web/src/context/modalConfirmationContext.tsx
+++ b/src/web/src/context/modalConfirmationContext.tsx
@@ -26,7 +26,7 @@ const useModalShow = (): UseModalShowReturnType => {
 interface ModalContextType {
   showConfirmation: (
     title: string,
-    message: string | JSX.Element,
+    message: string | React.ReactElement,
     showCancelButton?: boolean,
     showOkButton?: boolean,
   ) => Promise<boolean>;
@@ -46,7 +46,7 @@ const ConfirmationModalContextProvider: React.FC<
   const { setShow, show, onHide } = useModalShow();
   const [content, setContent] = useState<{
     title: string;
-    message: string | JSX.Element;
+    message: string | React.ReactElement;
     showCancelButton?: boolean;
     showOkButton?: boolean;
   } | null>();
@@ -56,7 +56,7 @@ const ConfirmationModalContextProvider: React.FC<
     () =>
       (
         title: string,
-        message: string | JSX.Element,
+        message: string | React.ReactElement,
         showCancelButton?: boolean,
         showOkButton?: boolean,
       ): Promise<boolean> => {

--- a/src/web/yarn.lock
+++ b/src/web/yarn.lock
@@ -4544,7 +4544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:*":
+"@types/minimatch@npm:5.1.2":
   version: 5.1.2
   resolution: "@types/minimatch@npm:5.1.2"
   checksum: 10c0/83cf1c11748891b714e129de0585af4c55dd4c2cafb1f1d5233d79246e5e1e19d1b5ad9e8db449667b3ffa2b6c80125c429dbee1054e9efb45758dbc4e118562


### PR DESCRIPTION
- Replace deprecated global JSX.Element with React.ReactElement in OpportunityStatus.tsx, SettingsForm.tsx, and modalConfirmationContext.tsx
- Pin @types/minimatch to 5.1.2 via resolutions to fix TypeScript build error caused by stub @types/minimatch@6.0.0 (empty main field)
- Regenerate yarn.lock