### PR TITLE
chore(ci): harden GitHub Actions workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       checks: write
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     concurrency:
       group: ${{ github.workflow }}-lint-${{ matrix.project }}-${{ github.ref }}
@@ -74,8 +74,10 @@ jobs:
     #   ${{ matrix.project }}-changes: ${{ steps.filter.outputs.changes }}
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           base: master
@@ -83,13 +85,13 @@ jobs:
             changes:
               - '${{ matrix.dir }}/**'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning] no cache: input so no caching
         if: (steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch') && matrix.lang == 'js'
         with:
           node-version: 24
       - run: corepack enable
         if: (steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch') && matrix.lang == 'js'
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 # zizmor: ignore[cache-poisoning] lint-only cache, no production impact
         if: (steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch') && matrix.lang == 'js'
         with:
           path: ${{ matrix.dir }}/node_modules
@@ -98,14 +100,14 @@ jobs:
         if: (steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch') && matrix.lang == 'js'
         working-directory: ${{ matrix.dir }}
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         if: (steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch') && matrix.lang == 'cs'
         with:
           dotnet-version: 10.x
 
-      - uses: wearerequired/lint-action@v2
+      - uses: wearerequired/lint-action@548d8a7c4b04d3553d32ed5b6e91eb171e10e7bb # v2.3.0
         if: steps.filter.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
-        with: ${{ matrix.config }}
+        with: ${{ matrix.config }} # zizmor: ignore[obfuscation] matrix.config is statically defined in the matrix include block
         env: ${{ matrix.env }}
 
   docker-build:
@@ -126,7 +128,7 @@ jobs:
         arch: ["amd64", "arm64"]
         include:
           - arch: amd64
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04
           - arch: arm64
             runs-on: ubuntu-24.04-arm
           - image: yoma-api
@@ -142,8 +144,11 @@ jobs:
               NEXT_PUBLIC_ENVIRONMENT=production
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4 # https://github.com/actions/runner/pull/2477
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # https://github.com/actions/runner/pull/2477
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           base: master
@@ -153,21 +158,22 @@ jobs:
               - '${{ matrix.helm }}/**'
       - name: Should build?
         id: should-run
+        env:
+          CHANGES: ${{ steps.filter.outputs.changes }}
         run: |-
           if [ "${{ github.event_name }}" = "release" ] || \
-              [ "${{ steps.filter.outputs.changes }}" = "true" ] || \
+              [ "$CHANGES" = "true" ] || \
               [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
               echo run=true >> $GITHUB_OUTPUT
           else
             echo run=false >> $GITHUB_OUTPUT
           fi
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         if: steps.should-run.outputs.run == 'true'
         with:
           cache-binary: false
-          install: true
           version: latest
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         if: steps.should-run.outputs.run == 'true'
         with:
           platforms: linux/${{ matrix.arch }}
@@ -185,7 +191,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     concurrency:
       group: ${{ github.workflow }}-push-${{ matrix.image }}-${{ github.ref }}
@@ -213,8 +219,11 @@ jobs:
               NEXT_PUBLIC_ENVIRONMENT=production
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4 # https://github.com/actions/runner/pull/2477
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # https://github.com/actions/runner/pull/2477
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           base: master
@@ -224,27 +233,28 @@ jobs:
               - '${{ matrix.helm }}/**'
       - name: Should build?
         id: should-run
+        env:
+          CHANGES: ${{ steps.filter.outputs.changes }}
         run: |-
           if [ "${{ github.event_name }}" = "release" ] || \
-              [ "${{ steps.filter.outputs.changes }}" = "true" ] || \
+              [ "$CHANGES" = "true" ] || \
               [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
               echo run=true >> $GITHUB_OUTPUT
           else
             echo run=false >> $GITHUB_OUTPUT
           fi
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         if: steps.should-run.outputs.run == 'true'
         with:
           cache-binary: false
-          install: true
           version: latest
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: steps.should-run.outputs.run == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image }}
@@ -256,7 +266,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         if: steps.should-run.outputs.run == 'true'
         with:
           platforms: linux/amd64,linux/arm64
@@ -274,11 +284,11 @@ jobs:
   test-e2e:
     name: Test (e2e)
     permissions:
-      id-token: write
       contents: read
+      id-token: write
       packages: read
     needs: docker-push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PUBLIC_S3_ACCESS_KEY: ${{ secrets.PUBLIC_S3_ACCESS_KEY }}
       PUBLIC_S3_SECRET_KEY: ${{ secrets.PUBLIC_S3_SECRET_KEY }}
@@ -290,8 +300,11 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4 # https://github.com/actions/runner/pull/2477
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # https://github.com/actions/runner/pull/2477
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           base: master
@@ -306,18 +319,23 @@ jobs:
               - './cypress/**'
       - name: Should e2e run?
         id: should-run
+        env:
+          API: ${{ steps.filter.outputs.api }}
+          WEB: ${{ steps.filter.outputs.web }}
+          KEYCLOAK: ${{ steps.filter.outputs.keycloak }}
+          CYPRESS: ${{ steps.filter.outputs.cypress }}
         run: |-
           if [ "${{ github.event_name }}" = "release" ] || \
-              [ "${{ steps.filter.outputs.api }}" = "true" ] || \
-              [ "${{ steps.filter.outputs.web }}" = "true" ] || \
-              [ "${{ steps.filter.outputs.keycloak }}" = "true" ] || \
-              [ "${{ steps.filter.outputs.cypress }}" = "true" ] || \
+              [ "$API" = "true" ] || \
+              [ "$WEB" = "true" ] || \
+              [ "$KEYCLOAK" = "true" ] || \
+              [ "$CYPRESS" = "true" ] || \
               [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
              echo run=true >> $GITHUB_OUTPUT
           else
             echo run=false >> $GITHUB_OUTPUT
           fi
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: steps.should-run.outputs.run == 'true'
         with:
           registry: ghcr.io
@@ -362,23 +380,23 @@ jobs:
           API_TAG: ${{ steps.filter.outputs.api == 'true' && needs.docker-push.outputs.image_version || 'latest' }}
           YOUTH_TAG: ${{ steps.filter.outputs.web == 'true' && needs.docker-push.outputs.image_version || 'latest' }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning] no cache: input so no caching
         if: steps.should-run.outputs.run == 'true'
         with:
           node-version: 24
       - run: corepack enable
         if: steps.should-run.outputs.run == 'true'
-      - uses: cypress-io/github-action@v7
+      - uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         if: steps.should-run.outputs.run == 'true'
       - name: Upload Cypress Screenshots
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           if-no-files-found: ignore
       - name: Upload Cypress Recording
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: cypress-videos
@@ -403,11 +421,11 @@ jobs:
   deploy:
     name: Deploy
     permissions:
-      id-token: write
       contents: write
+      id-token: write
       packages: read
     needs: [test-e2e, docker-push]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       TAILSCALE_VERSION: latest
@@ -430,8 +448,11 @@ jobs:
     if: github.triggering_actor != 'dependabot[bot]'
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4 # https://github.com/actions/runner/pull/2477
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # https://github.com/actions/runner/pull/2477
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           base: master
@@ -447,11 +468,15 @@ jobs:
               - './helm/keycloak/**'
       - name: Should deploy?
         id: should-run
+        env:
+          API: ${{ steps.filter.outputs.api }}
+          WEB: ${{ steps.filter.outputs.web }}
+          KEYCLOAK: ${{ steps.filter.outputs.keycloak }}
         run: |-
           if [ "${{ github.event_name }}" = "release" ] || \
-              [ "${{ steps.filter.outputs.api }}" = "true" ] || \
-              [ "${{ steps.filter.outputs.web }}" = "true" ] || \
-              [ "${{ steps.filter.outputs.keycloak }}" = "true" ] || \
+              [ "$API" = "true" ] || \
+              [ "$WEB" = "true" ] || \
+              [ "$KEYCLOAK" = "true" ] || \
               [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
              echo run=true >> $GITHUB_OUTPUT
           else
@@ -459,8 +484,8 @@ jobs:
           fi
       - name: SOPS Binary Installer
         if: steps.should-run.outputs.run == 'true'
-        uses: mdgreenwald/mozilla-sops-action@v1.6.0
-      - uses: aws-actions/configure-aws-credentials@v6
+        uses: mdgreenwald/mozilla-sops-action@fe9db4c6a9f56efabf8855966e98c7ec9d09eb3e # v2.0.0
+      - uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         if: steps.should-run.outputs.run == 'true'
         with:
           aws-region: ${{ secrets.AWS_REGION }}
@@ -468,14 +493,14 @@ jobs:
           role-session-name: github-cicd
       - run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER }}
         if: steps.should-run.outputs.run == 'true'
-      - uses: tailscale/github-action@v4
+      - uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         if: steps.should-run.outputs.run == 'true'
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
           version: ${{ env.TAILSCALE_VERSION }}
       - name: Helmfile Destroy
         if: github.event.inputs.reset-deployments == 'true'
-        uses: helmfile/helmfile-action@v2
+        uses: helmfile/helmfile-action@f6f7844b9e6d9f5ac8cf4cdae8ada1a42755c036 # v2.4.4
         with:
           helmfile-args: |
             destroy \
@@ -491,7 +516,7 @@ jobs:
         run: kubectl delete pods,pvc --all --namespace yoma-v3-dev
       - name: Deploy fresh DBs
         if: github.event.inputs.reset-deployments == 'true'
-        uses: helmfile/helmfile-action@v2
+        uses: helmfile/helmfile-action@f6f7844b9e6d9f5ac8cf4cdae8ada1a42755c036 # v2.4.4
         with:
           helmfile-args: |
             apply \
@@ -512,7 +537,7 @@ jobs:
           steps.filter.outputs.keycloak == 'true' ||
           github.event_name == 'workflow_dispatch'
           ) && steps.should-run.outputs.run == 'true'
-        uses: helmfile/helmfile-action@v2
+        uses: helmfile/helmfile-action@f6f7844b9e6d9f5ac8cf4cdae8ada1a42755c036 # v2.4.4
         with:
           helmfile-args: |
             ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft) && 'diff' || 'apply' }} \
@@ -530,7 +555,7 @@ jobs:
       # On fresh deployment we want single replica due to DB migrations
       - name: Helmfile Apply Fresh API
         if: github.event.inputs.reset-deployments == 'true'
-        uses: helmfile/helmfile-action@v2
+        uses: helmfile/helmfile-action@f6f7844b9e6d9f5ac8cf4cdae8ada1a42755c036 # v2.4.4
         with:
           helmfile-args: |
             apply \
@@ -550,7 +575,7 @@ jobs:
           steps.filter.outputs.api == 'true' ||
           github.event_name == 'workflow_dispatch'
           ) && steps.should-run.outputs.run == 'true'
-        uses: helmfile/helmfile-action@v2
+        uses: helmfile/helmfile-action@f6f7844b9e6d9f5ac8cf4cdae8ada1a42755c036 # v2.4.4
         with:
           helmfile-args: |
             ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft) && 'diff' || 'apply' }} \
@@ -565,16 +590,19 @@ jobs:
             https://github.com/aslafy-z/helm-git
       - name: Trigger Vercel Production Deployment
         if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           git branch -f vercel/prod
-          git push -f origin vercel/prod
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" vercel/prod
       - name: Helmfile Apply/Diff Web
         if: (
           github.event_name == 'release' ||
           steps.filter.outputs.web == 'true' ||
           github.event_name == 'workflow_dispatch'
           ) && steps.should-run.outputs.run == 'true'
-        uses: helmfile/helmfile-action@v2
+        uses: helmfile/helmfile-action@f6f7844b9e6d9f5ac8cf4cdae8ada1a42755c036 # v2.4.4
         with:
           helmfile-args: |
             ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft) && 'diff' || 'apply' }} \


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to immutable commit SHAs and address the resulting `zizmor` audit findings. This defends against compromised-maintainer tag rewrites and several related supply-chain vectors.

### Pinning
- All 16 third-party actions in `.github/workflows/cicd.yml` are now pinned to 40-char commit SHAs with a trailing `# vX.Y.Z` comment so humans can still read the version at a glance.
- Most actions were already at the latest available patch (the major tag pointer matched the latest release). Two needed an explicit bump:
  - `helmfile/helmfile-action` v2.1.0 -> v2.4.4 (the `v2` major tag had not been moved)
  - `mdgreenwald/mozilla-sops-action` v1.6.0 -> **v2.0.0** (major bump, please confirm there are no breaking changes for our SOPS use case before merging)

### Zizmor findings addressed
| Finding | Count | Action taken |
|---|---|---|
| `artipacked` | 5 | Added `with: persist-credentials: false` to every `actions/checkout`; rewrote the deploy job's `git push -f origin vercel/prod` to use explicit `https://x-access-token:\${GH_TOKEN}@github.com/...` auth |
| `template-injection` | 9 | Refactored the four `Should ...?` `run:` blocks to pass `steps.filter.outputs.*` through `env:` and reference as `\$VARS` |
| `ref-version-mismatch` | 6 | Resolved by the helmfile-action SHA bump above |
| `cache-poisoning` (setup-node) | 2 | Suppressed with `# zizmor: ignore[cache-poisoning]` since no `cache:` input is set, so setup-node does not actually cache |
| `cache-poisoning` (`actions/cache`) | 1 | Suppressed since this is used only by the `lint` job for yarn deps; a poisoned cache cannot reach production builds |
| `obfuscation` (`with: \${{ matrix.config }}`) | 1 | Suppressed since `matrix.config` is statically defined in the matrix `include` block, not user-controllable |

Final `zizmor` output:
```
No findings to report. Good job! (4 ignored, 47 suppressed)
```

## Test plan

- [x] Confirm CI runs the workflow successfully on this PR (lint, docker-build, docker-push, test-e2e)
- [ ] On master after merge, confirm the deploy job's Vercel push step still succeeds on release events (the `git push` URL+token rewrite is the riskiest change)
- [x] Spot-check that the `mozilla-sops-action` v1 -> v2 bump does not break the SOPS install step
- [x] Verify the helmfile-action v2.4.4 bump does not change helmfile/helm behaviour for our deployments