### PR TITLE
chore(web): pin pnpm version and relax node engine

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -86,7 +86,8 @@
   "ct3aMetadata": {
     "initVersion": "7.16.0"
   },
+  "packageManager": "pnpm@11.2.0",
   "engines": {
-    "node": "24.x"
+    "node": "^24.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add `packageManager` field set to `pnpm@11.2.0` in `src/web/package.json` so Corepack and CI agents resolve a consistent pnpm version, following the recent yarn → pnpm migration (#1808).
- Relax `engines.node` from `24.x` to `^24.0.0` to accept any 24.x minor/patch without requiring a manifest bump per Node release.