### PR TITLE
ci: native multi-arch image builds and GHCR/cache cleanup

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -118,6 +118,7 @@ jobs:
     name: Build Docker Images
     permissions:
       contents: read
+      packages: write
     runs-on: ${{ matrix.runs-on }}
 
     concurrency:
@@ -177,13 +178,20 @@ jobs:
         with:
           cache-binary: false
           version: latest
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        if: steps.should-run.outputs.run == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
       - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         if: steps.should-run.outputs.run == 'true'
         with:
           platforms: linux/${{ matrix.arch }}
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          push: false
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ matrix.image }}:sha-${{ github.sha }}-${{ matrix.arch }}
           cache-from: |
             type=gha,scope=build-${{ matrix.image }}-${{ matrix.arch }}
             type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:latest
@@ -213,14 +221,9 @@ jobs:
           - image: yoma-api
             context: ./src/api
             helm: ./helm/yoma-api
-            file: ./src/api/Dockerfile
-            buildArgs: ""
           - image: yoma-web
             context: .
             helm: ./helm/yoma-web
-            file: ./src/web/Dockerfile
-            buildArgs: |-
-              NEXT_PUBLIC_ENVIRONMENT=production
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -270,20 +273,24 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - name: Create and push multi-arch manifest
         if: steps.should-run.outputs.run == 'true'
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha,scope=build-${{ matrix.image }}-arm64
-            type=gha,scope=build-${{ matrix.image }}-amd64
-            type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:latest
-          build-args: ${{ matrix.buildArgs }}
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE: ${{ matrix.image }}
+          SHA: ${{ github.sha }}
+        run: |-
+          # Combine the per-arch images pushed by docker-build into one manifest list per tag
+          echo "$TAGS" | while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              echo "Creating manifest for: $tag"
+              docker buildx imagetools create \
+                --tag "$tag" \
+                "${REGISTRY}/${IMAGE}:sha-${SHA}-amd64" \
+                "${REGISTRY}/${IMAGE}:sha-${SHA}-arm64"
+            fi
+          done
 
   test-e2e:
     name: Test (e2e)

--- a/.github/workflows/clean-cache.yaml
+++ b/.github/workflows/clean-cache.yaml
@@ -1,0 +1,36 @@
+name: Clean PR Cache
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Clean PR Cache
+    runs-on: ubuntu-24.04
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
+    steps:
+      - name: Cleanup
+        run: |-
+          echo "Fetching list of cache key"
+          mapfile -t cacheKeysForPR < <(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in "${cacheKeysForPR[@]}"; do
+            echo "Deleting cache with key: ${cacheKey}"
+            gh cache delete "$cacheKey"
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,40 @@
+name: GHCR Cleanup
+
+# Prune sha-*, pr-*, and untagged images older than 14 days.
+# latest, branch (<branch>, <branch>-<sha>), and semver/release tags are intentionally preserved.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run: log deletions without removing anything"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Prune old images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
+        with:
+          owner: ${{ github.repository_owner }}
+          packages: yoma-api,yoma-web
+          older-than: 14 days
+          delete-tags: sha-*,pr-*
+          delete-untagged: true
+          validate: true
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}


### PR DESCRIPTION
## Summary
- **Native multi-arch builds** in `cicd.yml`: each arch builds on its own native runner and pushes a per-arch tag (`sha-<sha>-<arch>`), then `docker buildx imagetools create` stitches them into a single multi-arch manifest. Removes the slow QEMU-emulated arm64 path that previously ran on amd64.
- **`ghcr-cleanup.yml`**: scheduled daily prune of `sha-*`, `pr-*`, and untagged GHCR images older than 14 days, preserving `latest`, branch, and semver tags. Mirrors the ECR lifecycle policy used elsewhere.
- **`clean-cache.yaml`**: deletes a PR's Actions caches once the PR is closed.