### PR TITLE
ci(ghcr-cleanup): retain 50 most recent matching tags

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,7 +1,8 @@
 name: GHCR Cleanup
 
 # Prune sha-*, pr-*, and untagged images older than 14 days.
-# latest, branch (<branch>, <branch>-<sha>), and semver/release tags are intentionally preserved.
+# For master-* tags, keep the 50 most recent.
+# latest and semver/release tags are intentionally preserved.
 
 on:
   schedule:
@@ -29,12 +30,24 @@ jobs:
       packages: write
 
     steps:
-      - uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
+      - name: Prune sha-*, pr-*, and untagged images older than 14 days
+        uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
         with:
           owner: ${{ github.repository_owner }}
           packages: yoma-api,yoma-web
           older-than: 14 days
           delete-tags: sha-*,pr-*
           delete-untagged: true
+          keep-n-tagged: 50
+          validate: true
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+
+      - name: Prune master-* tags (keep 50 most recent)
+        uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
+        with:
+          owner: ${{ github.repository_owner }}
+          packages: yoma-api,yoma-web
+          delete-tags: master-*
+          keep-n-tagged: 50
           validate: true
           dry-run: ${{ github.event.inputs.dry-run || 'false' }}


### PR DESCRIPTION
## Summary

- Add `keep-n-tagged: 50` to the existing cleanup step so the 50 newest `sha-*` / `pr-*` images older than 14 days are retained instead of pruned.
- Add a second cleanup step that targets `master-*` tags and keeps the 50 most recent (no age filter), so every push to master no longer leaves a `master-<sha>` tag in GHCR indefinitely.

## Behavior summary

Step 1 (`older-than: 14 days`, `delete-tags: sha-*,pr-*`, `keep-n-tagged: 50`, `delete-untagged: true`):

- `sha-*` / `pr-*` images older than 14 days → keep the 50 newest across both patterns, delete the rest
- Untagged images older than 14 days → deleted
- `master-*`, `latest`, semver, anything younger than 14 days → untouched

Step 2 (`delete-tags: master-*`, `keep-n-tagged: 50`):

- `master-*` images → keep the 50 newest, delete the rest
- All other tagged images and untagged images → untouched

Cross-checked against the `dataaxiom/ghcr-cleanup-action` source: when `delete-tags` and `keep-n-tagged` are both set, the standard `delete-tags` deletion is skipped and `keep-n-tagged` handles all deletions, with its candidate set scoped to tags matching `delete-tags` (`deletion-strategy.ts` `collectKeepNTaggedCandidates`).

## Test plan

- [x] Trigger the workflow manually with `dry-run: true` via `workflow_dispatch`
- [x] Confirm step 1 logs show ≤ 50 `sha-*`/`pr-*` images retained per package
- [x] Confirm step 2 logs show ≤ 50 `master-*` images retained per package
- [x] Confirm no `latest` or semver tags appear in either step's deletion plan