### PR TITLE
chore: bump Datadog auto-instrumentation lib versions

### DIFF
--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -375,7 +375,7 @@ keycloak:
     admission.datadoghq.com/enabled: "false" # disabled by default (for now)
   podAnnotations:
     # gcr.io/datadoghq/dd-lib-java-init
-    admission.datadoghq.com/java-lib.version: v1.53.0
+    admission.datadoghq.com/java-lib.version: v1.63.0
     ad.datadoghq.com/keycloak.logs: '[{ "service": "keycloak", "source": "jboss_wildfly" }]'
 
   lifecycleHooks: |-

--- a/helm/yoma-api/values.yaml
+++ b/helm/yoma-api/values.yaml
@@ -26,7 +26,7 @@ serviceAccount:
 podAnnotations:
   ad.datadoghq.com/yoma-api.logs: '[{ "service" : "yoma-api", "source" : "csharp"}]'
   # gcr.io/datadoghq/dd-lib-dotnet-init
-  admission.datadoghq.com/dotnet-lib.version: v3.19.0
+  admission.datadoghq.com/dotnet-lib.version: v3.45.0
 deploymentLabels:
   tags.datadoghq.com/service: yoma-api
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/helm/yoma-web/values.yaml
+++ b/helm/yoma-web/values.yaml
@@ -25,7 +25,7 @@ serviceAccount:
 
 podAnnotations:
   # gcr.io/datadoghq/dd-lib-js-init
-  admission.datadoghq.com/js-lib.version: v5.48.0
+  admission.datadoghq.com/js-lib.version: v5.105.0
 deploymentLabels:
   tags.datadoghq.com/service: yoma-web
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -34,12 +34,10 @@ podLabels:
   tags.datadoghq.com/service: yoma-web
   tags.datadoghq.com/version: "{{ .Values.image.tag | default .Chart.AppVersion }}"
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
## Summary

Bumps the Datadog APM auto-instrumentation library versions pinned in the pod annotations across all three services. These had drifted well behind the upstream releases, so this pulls them current to pick up bug fixes and tracer improvements.

| Service | Annotation | From | To |
| --- | --- | --- | --- |
| `keycloak` | `admission.datadoghq.com/java-lib.version` | `v1.53.0` | `v1.63.0` |
| `yoma-api` | `admission.datadoghq.com/dotnet-lib.version` | `v3.19.0` | `v3.45.0` |
| `yoma-web` | `admission.datadoghq.com/js-lib.version` | `v5.48.0` | `v5.105.0` |

Also tidies the inline `podSecurityContext` and `securityContext` formatting in the `yoma-web` values.

## Notes

These versions are injected by the Datadog admission controller at pod startup, so the change takes effect on the next rollout of each service.
