### PR TITLE
fix(health): separate liveness from readiness and quiet probe cancellations

### DIFF
--- a/src/api/src/application/Yoma.Core.Api/Middleware/ExceptionLogMiddleware.cs
+++ b/src/api/src/application/Yoma.Core.Api/Middleware/ExceptionLogMiddleware.cs
@@ -50,6 +50,7 @@ namespace Yoma.Core.Api.Middleware
     {
       FluentValidation.ValidationException or ValidationException => (LogLevel.Information, HttpStatusCode.BadRequest),
       EntityNotFoundException => (LogLevel.Information, HttpStatusCode.NotFound),
+      OperationCanceledException => (LogLevel.Information, (HttpStatusCode)499),
       SecurityException or System.Security.SecurityException => (LogLevel.Warning, HttpStatusCode.Unauthorized),
       HttpClientException http => http.StatusCode switch
       {

--- a/src/api/src/application/Yoma.Core.Api/Startup.cs
+++ b/src/api/src/application/Yoma.Core.Api/Startup.cs
@@ -116,7 +116,7 @@ namespace Yoma.Core.Api
 
       services.AddHttpContextAccessor();
       services.AddMemoryCache();
-      services.AddHealthChecks().AddCheck("API Ready Check", () => HealthCheckResult.Healthy("API is up"), tags: ["ready"]);
+      services.AddHealthChecks().AddCheck("API Ready Check", () => HealthCheckResult.Healthy("API is up"), tags: ["live"]);
       #endregion
 
       #region 3rd Party

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Startup.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Startup.cs
@@ -61,7 +61,7 @@ namespace Yoma.Core.Infrastructure.Database
       services.AddHealthChecks().AddNpgSql(
         connectionString: configuration.Configuration_ConnectionString(),
         name: "Database Connectivity Check",
-        tags: ["live"]);
+        tags: ["ready"]);
 
       //<PackageReference Include="EntityFrameworkProfiler.Appender" Version="6.0.6040" />
       //if (environment == Domain.Core.Environment.Local)


### PR DESCRIPTION
- Move Postgres connectivity check from "live" to "ready" tag so a DB blip pulls pods out of the load balancer instead of restarting them.
- /health/live now only tests in-process responsiveness; /health/ready exercises the DB.
- Classify OperationCanceledException (incl. TaskCanceledException) as Information in ExceptionLogMiddleware to stop probe/client-disconnect cancellations being logged as Errors and surfacing in Sentry.