### PR TITLE
Refactor Alison auth and short-circuit missing email

### DIFF
--- a/src/api/src/application/Yoma.Core.Api/Yoma.Core.Api.csproj
+++ b/src/api/src/application/Yoma.Core.Api/Yoma.Core.Api.csproj
@@ -20,13 +20,13 @@
 	<PackageReference Include="Hangfire.Core" Version="1.8.23" />
 	<PackageReference Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />
 	<PackageReference Include="Hangfire.PostgreSql" Version="1.21.1" />
-	<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.8" />
-	<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+	<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.9" />
+	<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
 	<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.1" />
-	<PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="10.2.1" />
+	<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.2" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.2" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.2" />
+	<PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="10.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/src/domain/Yoma.Core.Domain/PartnerSync/Models/SyncResultUserAuthentication.cs
+++ b/src/api/src/domain/Yoma.Core.Domain/PartnerSync/Models/SyncResultUserAuthentication.cs
@@ -10,9 +10,9 @@ namespace Yoma.Core.Domain.PartnerSync.Models
     /// </summary>
     public string URL { get; set; } = null!;
 
-    /// <summary>
-    /// Updated partner-specific user link produced by the authentication/linking flow.
+    /// Optional updated partner-specific user link produced by the authentication/linking flow.
+    /// Null when authentication is skipped or no partner-side user link was created or updated.
     /// </summary>
-    public SyncInfoUserPartner UserSyncInfo { get; set; } = null!;
+    public SyncInfoUserPartner? UserSyncInfo { get; set; }
   }
 }

--- a/src/api/src/domain/Yoma.Core.Domain/Yoma.Core.Domain.csproj
+++ b/src/api/src/domain/Yoma.Core.Domain/Yoma.Core.Domain.csproj
@@ -39,15 +39,15 @@
     <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />
-    <PackageReference Include="libphonenumber-csharp" Version="9.0.31" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.32" />
     <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NSwag.Annotations" Version="14.7.1" />
     <PackageReference Include="QRCoder" Version="1.8.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
+    <PackageReference Include="StackExchange.Redis" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Alison/Client/AlisonClient.cs
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Alison/Client/AlisonClient.cs
@@ -138,7 +138,7 @@ namespace Yoma.Core.Infrastructure.Alison.Client
     {
       ArgumentNullException.ThrowIfNull(request);
 
-      var entityExternalId = ValidateAndResolveUserAuthenticationRequest(request);
+      ValidateAndNormalizeUserAuthenticationRequest(request);
 
       if (!_appSettings.PartnerSyncEnabledEnvironmentsAsEnum.HasFlag(_environmentProvider.Environment))
       {
@@ -150,9 +150,19 @@ namespace Yoma.Core.Infrastructure.Alison.Client
         return AuthenticationMock(request);
       }
 
-      return !string.IsNullOrWhiteSpace(request.UserSyncInfo?.ExternalId)
-        ? await LoginExistingUser(request, entityExternalId)
-        : await RegisterOrLoginUser(request, entityExternalId);
+      // Alison supports email-based user authentication only.
+      // When no real email is available, fall back to the default external URL.
+      if (string.IsNullOrEmpty(request.Email))
+      {
+        if (_logger.IsEnabled(LogLevel.Information))
+          _logger.LogInformation(
+            "Skipping Alison user authentication for Yoma user '{userId}' because Alison requires a real email address. The default partner navigation URL will be used",
+            request.UserId);
+
+        return new SyncResultUserAuthentication { URL = request.EntitySyncInfo.URL! };
+      }
+
+      return !string.IsNullOrEmpty(request.UserSyncInfo?.ExternalId) ? await LoginExistingUser(request) : await RegisterOrLoginUser(request);
     }
 
     public Task<SyncResultPullEntity<Domain.Opportunity.Models.Opportunity>> List(SyncFilterPullEntity filter)
@@ -188,10 +198,10 @@ namespace Yoma.Core.Infrastructure.Alison.Client
 
     #region Private Members
     /// <summary>
-    /// Validates that the user-authentication request belongs to Alison and contains the
-    /// partner entity context required to build an authenticated Alison course URL.
+    /// Validates that the user-authentication request belongs to Alison and
+    /// normalizes request values in place for downstream processing.
     /// </summary>
-    private static string ValidateAndResolveUserAuthenticationRequest(SyncRequestUserAuthentication request)
+    private static void ValidateAndNormalizeUserAuthenticationRequest(SyncRequestUserAuthentication request)
     {
       ArgumentNullException.ThrowIfNull(request);
       ArgumentNullException.ThrowIfNull(request.EntitySyncInfo);
@@ -199,11 +209,18 @@ namespace Yoma.Core.Infrastructure.Alison.Client
       if (request.EntitySyncInfo.Partner != SyncPartner.Alison)
         throw new InvalidOperationException($"Partner '{request.EntitySyncInfo.Partner}' not supported by Alison user authentication");
 
-      var entityExternalId = request.EntitySyncInfo.ExternalId?.Trim();
-      if (string.IsNullOrWhiteSpace(entityExternalId))
+      request.EntitySyncInfo.ExternalId = request.EntitySyncInfo.ExternalId?.Trim();
+      if (string.IsNullOrEmpty(request.EntitySyncInfo.ExternalId))
         throw new InvalidOperationException("Alison course external id is required for user authentication");
 
-      return entityExternalId;
+      request.EntitySyncInfo.URL = request.EntitySyncInfo.URL?.Trim();
+      if (string.IsNullOrEmpty(request.EntitySyncInfo.URL))
+        throw new InvalidOperationException("Default Alison navigation URL is required for user authentication");
+
+      request.Email = request.Email?.Trim();
+      request.FirstName = request.FirstName?.Trim();
+      request.Surname = request.Surname?.Trim();
+      request.UserSyncInfo?.ExternalId = request.UserSyncInfo.ExternalId?.Trim();
     }
 
     /// <summary>
@@ -215,15 +232,11 @@ namespace Yoma.Core.Infrastructure.Alison.Client
     /// </summary>
     private static SyncResultUserAuthentication AuthenticationMock(SyncRequestUserAuthentication request)
     {
-      var url = request.EntitySyncInfo!.URL?.Trim();
-      if (string.IsNullOrWhiteSpace(url))
-        throw new InvalidOperationException("Default Alison navigation URL is required when partner synchronization is disabled");
-
-      var externalId = request.UserSyncInfo?.ExternalId?.Trim() ?? $"mock-alison-user-{request.UserId}";
+      var externalId = request.UserSyncInfo?.ExternalId ?? $"mock-alison-user-{request.UserId}";
 
       return new SyncResultUserAuthentication
       {
-        URL = url,
+        URL = request.EntitySyncInfo.URL!,
         UserSyncInfo = new SyncInfoUserPartner
         {
           Partner = SyncPartner.Alison,
@@ -236,9 +249,7 @@ namespace Yoma.Core.Infrastructure.Alison.Client
     /// <summary>
     /// Logs in an already-linked Alison user and returns an authenticated Alison course URL.
     /// </summary>
-    private async Task<SyncResultUserAuthentication> LoginExistingUser(
-      SyncRequestUserAuthentication request,
-      string entityExternalId)
+    private async Task<SyncResultUserAuthentication> LoginExistingUser(SyncRequestUserAuthentication request)
     {
       if (_logger.IsEnabled(LogLevel.Information))
         _logger.LogInformation(
@@ -247,7 +258,6 @@ namespace Yoma.Core.Infrastructure.Alison.Client
 
       var (_, Authentication) = await Authenticate(
         request,
-        entityExternalId,
         UserAuthenticationRequestType.Login);
 
       return Authentication ?? throw new InvalidOperationException("Alison login authentication result expected");
@@ -261,12 +271,10 @@ namespace Yoma.Core.Infrastructure.Alison.Client
     /// returned Alison user id through the normal domain user-sync-info update flow.
     /// </summary>
     private async Task<SyncResultUserAuthentication> RegisterOrLoginUser(
-      SyncRequestUserAuthentication request,
-      string entityExternalId)
+      SyncRequestUserAuthentication request)
     {
       var (StatusCode, Authentication) = await Authenticate(
         request,
-        entityExternalId,
         UserAuthenticationRequestType.Register,
         [HttpStatusCode.UnprocessableEntity]);
 
@@ -280,7 +288,6 @@ namespace Yoma.Core.Infrastructure.Alison.Client
 
       var loginResult = await Authenticate(
         request,
-        entityExternalId,
         UserAuthenticationRequestType.Login);
 
       return loginResult.Authentication ?? throw new InvalidOperationException("Alison login authentication result expected");
@@ -296,7 +303,6 @@ namespace Yoma.Core.Infrastructure.Alison.Client
     /// </summary>
     private async Task<(HttpStatusCode StatusCode, SyncResultUserAuthentication? Authentication)> Authenticate(
       SyncRequestUserAuthentication request,
-      string entityExternalId,
       UserAuthenticationRequestType requestType,
       List<HttpStatusCode>? additionalSuccessStatusCodes = null)
     {
@@ -325,7 +331,7 @@ namespace Yoma.Core.Infrastructure.Alison.Client
       return (statusCode, responseParsed.ToSyncResultUserAuthentication(
         _options,
         request,
-        entityExternalId,
+        request.EntitySyncInfo.ExternalId!,
         requestType));
     }
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Alison/Yoma.Core.Infrastructure.Alison.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Alison/Yoma.Core.Infrastructure.Alison.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.AmazonS3/Yoma.Core.Infrastructure.AmazonS3.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.AmazonS3/Yoma.Core.Infrastructure.AmazonS3.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.2" />
-	<PackageReference Include="AWSSDK.S3" Version="4.0.23.6" />
+	<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.10" />
+	<PackageReference Include="AWSSDK.S3" Version="4.0.25.2" />
 	<PackageReference Include="tusdotnet" Version="2.11.1" />
   </ItemGroup>
 </Project>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.AriesCloud/Yoma.Core.Infrastructure.AriesCloud.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.AriesCloud/Yoma.Core.Infrastructure.AriesCloud.csproj
@@ -13,12 +13,12 @@
   
   <ItemGroup>
     <PackageReference Include="didx.aries-cloudapi-dotnet-aspcore" Version="1.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Chimoney/Yoma.Core.Infrastructure.Chimoney.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Chimoney/Yoma.Core.Infrastructure.Chimoney.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Yoma.Core.Infrastructure.Database.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Database/Yoma.Core.Infrastructure.Database.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Emsi/Yoma.Core.Infrastructure.Emsi.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Emsi/Yoma.Core.Infrastructure.Emsi.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Jobberman/Yoma.Core.Infrastructure.Jobberman.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Jobberman/Yoma.Core.Infrastructure.Jobberman.csproj
@@ -16,12 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Shared/Yoma.Core.Infrastructure.Shared.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Shared/Yoma.Core.Infrastructure.Shared.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Substack/Yoma.Core.Infrastructure.Substack.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Substack/Yoma.Core.Infrastructure.Substack.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Twillio/Yoma.Core.Infrastructure.Twilio.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Twillio/Yoma.Core.Infrastructure.Twilio.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libphonenumber-csharp" Version="9.0.31" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.32" />
     <PackageReference Include="Twilio" Version="7.14.9" />
   </ItemGroup>
 

--- a/src/api/src/infrastructure/Yoma.Core.Infrastructure.Zlto/Yoma.Core.Infrastructure.Zlto.csproj
+++ b/src/api/src/infrastructure/Yoma.Core.Infrastructure.Zlto/Yoma.Core.Infrastructure.Zlto.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/api/src/test/Yoma.Core.Test/Yoma.Core.Test.csproj
+++ b/src/api/src/test/Yoma.Core.Test/Yoma.Core.Test.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
- Clean up the Alison authentication flow and return early when no email is available, avoiding unnecessary partner sync/auth processing
- Updated packages