### PR TITLE
Fix Keycloak deploy under Helm 4 server-side apply

### DIFF
--- a/helm/keycloak/conf/dev/secrets.yaml
+++ b/helm/keycloak/conf/dev/secrets.yaml
@@ -43,8 +43,6 @@ config-cli:
         KEYCLOAK_USER: ENC[AES256_GCM,data:DQzrhhayQ2Q=,iv:NwgCJZuKx+D2gUcSc1T+Vv0LigPo8UFeiYgbBfvT0vM=,tag:arBptodK9nGgPVRqsk7zGQ==,type:str]
         SMTP_PASSWORD: ENC[AES256_GCM,data:OQ21EoS8EKAVUj4stgUUusSnJ8XvxhE/pHTgnNCaV93niWL/hV4ZhBZpaZARqfghF8CUT5mq9FMHz/Fze6Ihf7u1sjLx,iv:HaSfc3XVJjMORAaURaNnGCsZ67p++xzCKvMTPavmqzw=,tag:VjXqmWm0gjwRU+YRo55W4g==,type:str]
         SA_YOMA_API_PASSWORD: ENC[AES256_GCM,data:gi9I8jz8y6W5tzBl7928jTJxQdmqNu27rgqhEQ73Z2GA/mJHbzDIiw==,iv:9k+sOuX6CC5BmmmjLwJxtqzpLSPmFnHVbqVyAIklv4c=,tag:iUEEJ4MSvXmr4vPJX+J/lQ==,type:str]
-        CLIENT_GOODWALL_URL: ENC[AES256_GCM,data:TaraSZAv8f7NJE8QfNdFH2qncU9kew==,iv:ZYEOXqrFCS4qYop1qk4Z8rpPNjyiw9FVkmLT/eYMuRg=,tag:mmnAncZQ4y7Khh3K26MvNQ==,type:str]
-        CLIENT_GOODWALL_URL_REDIRECT: ENC[AES256_GCM,data:xFhQMVrl1bhuYlQnfurgIQxjT3SdUNVInmq7,iv:/qXnJDrk8bdgkvbahVIT9EVs9eEXolpwvwfWOHLDv5E=,tag:iW+E3pLWARAvFFEXts+7dQ==,type:str]
         CLIENT_YOMA_API_SECRET: ENC[AES256_GCM,data:8hjXOMC2ffiIclKEJ560Z051uYRENv2tQ1QjyOiW,iv:b+jvRE4IFhhtrAKjalIWvttompSYi5eOAUKhewcl3PQ=,tag:tABmg8KyoZ93Vq9yQyz4WQ==,type:str]
         CLIENT_ATINGI_SECRET: ENC[AES256_GCM,data:DlY0gi1K4PZhrwL0bUrbRdPkJj8OVPR/Henggpg=,iv:WIJmW95F6u+zkuQjTnRkqqJ58pYm9XWECKAJm1Q/gkY=,tag:wcB1LUwxwcMEubpy3MbH1A==,type:str]
         CLIENT_GOODWALL_SECRET: ENC[AES256_GCM,data:Y/IoysB71OyJtgQVgTa4Ypd19n1SsOmf1DoTKUg+KA==,iv:bs6fedJHR21Kr+dr29nQTNAVsoV0ztV8EjiOpku1EYA=,tag:OWBd7Y8RtR+Nodk0UKy70A==,type:str]
@@ -59,14 +57,14 @@ config-cli:
 sops:
     kms:
         - arn: arn:aws:kms:eu-west-1:210913241065:alias/helm/yoma-dev
-          created_at: "2023-07-27T08:52:40Z"
-          enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
           aws_profile: yoma-sso-dev
-        - arn: arn:aws:kms:eu-west-1:210913241065:alias/helm/yoma-dev
           created_at: "2023-07-27T08:52:40Z"
           enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
+        - arn: arn:aws:kms:eu-west-1:210913241065:alias/helm/yoma-dev
           aws_profile: ""
-    lastmodified: "2026-03-31T13:12:49Z"
-    mac: ENC[AES256_GCM,data:kzRQY/+ls59Po9IVJAf3GoXO1iYaJx9Bg1l+pRZez1gCyDR7AGmaZabGlTzo1eQT0DZ75uB1gY39sd0YkD3zESf0J/XfoewTsQbnVVF4c/oR93NUY8wRZCohQfuOlWXBZu8jalXpPv3jJiW/ZUaHzuehgI8Bz/n//rWXXzUVNlM=,iv:9cO+vdPUJDxOPHe5wToOWjCPJITkjzY87tpMZComEBE=,tag:67vmBPoQRRoBLFPSU2HAiA==,type:str]
+          created_at: "2023-07-27T08:52:40Z"
+          enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
+    lastmodified: "2026-07-13T10:07:27Z"
+    mac: ENC[AES256_GCM,data:vGrjJxAJoAoHEm2WjJ9u0F31y0Hvv/d7//8VWCusucmoY4dY+AcOJ8ue4Q0Z8hIfmjwiEGFetj3BZvQ8rbkmIOo19Di9WoYSn/vmRit2YnINpZwMCCl/cjWaNEf2PYhD7aPk/e+R3A4bqrU5LHpMNV1V6ZMFLMS1U/CTYMxby4g=,iv:SUZGnNXO1JeCgc1Vm9tn7ZiJ8+WALXKJitBZQdiqFU0=,tag:DWdhFWWS46X2cCu4UIOeWA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.2

--- a/helm/keycloak/conf/dev/values.yaml
+++ b/helm/keycloak/conf/dev/values.yaml
@@ -79,7 +79,7 @@ config-cli:
   env:
     KEYCLOAK_URL: https://dev.yoma.world/auth
     IMPORT_FILES_LOCATIONS: "/init/*.yaml"
-    # KEYCLOAK_USER: xxx
+    KEYCLOAK_USER: null
     # REALM_YOMA_ADMIN_CLI_SECRET: xxx
     # SMTP_PASSWORD: SG.xxx
     CLIENT_YOMA_API_URL: https://v3api.dev.yoma.world

--- a/helm/keycloak/conf/local/secrets.yaml
+++ b/helm/keycloak/conf/local/secrets.yaml
@@ -13,8 +13,6 @@ config-cli:
         KEYCLOAK_USER: ENC[AES256_GCM,data:DQzrhhayQ2Q=,iv:NwgCJZuKx+D2gUcSc1T+Vv0LigPo8UFeiYgbBfvT0vM=,tag:arBptodK9nGgPVRqsk7zGQ==,type:str]
         SMTP_PASSWORD: ENC[AES256_GCM,data:KMTlrEkouJiISvfPNa13E7yJ1oSSStyeVkVWVBIioJ1vxPTWLXzU2avVUgMPiAlYeeoFCkRhz46XKm2Jkm/bKxIOL3RI,iv:o0EkIyOvghMZjr+mFpI6lQCcd6U+OLunb7MlMtBqkfA=,tag:zOsiALs5R9nKUd9qe9cdcw==,type:str]
         SA_YOMA_API_PASSWORD: ENC[AES256_GCM,data:gi9I8jz8y6W5tzBl7928jTJxQdmqNu27rgqhEQ73Z2GA/mJHbzDIiw==,iv:9k+sOuX6CC5BmmmjLwJxtqzpLSPmFnHVbqVyAIklv4c=,tag:iUEEJ4MSvXmr4vPJX+J/lQ==,type:str]
-        CLIENT_GOODWALL_URL: ENC[AES256_GCM,data:cjKkXWhz9PMmKnxdJOFaSHocl8VMu0U=,iv:XRb4lvjGPRwKfnA0HfqmzdiYQWxpSE+n1CZ+SAvuy8U=,tag:9z+oy+0Sgl5ktQ03y3AT0A==,type:str]
-        CLIENT_GOODWALL_URL_REDIRECT: ENC[AES256_GCM,data:xFhQMVrl1bhuYlQnfurgIQxjT3SdUNVInmq7,iv:/qXnJDrk8bdgkvbahVIT9EVs9eEXolpwvwfWOHLDv5E=,tag:iW+E3pLWARAvFFEXts+7dQ==,type:str]
         CLIENT_YOMA_API_SECRET: ENC[AES256_GCM,data:8hjXOMC2ffiIclKEJ560Z051uYRENv2tQ1QjyOiW,iv:b+jvRE4IFhhtrAKjalIWvttompSYi5eOAUKhewcl3PQ=,tag:tABmg8KyoZ93Vq9yQyz4WQ==,type:str]
         CLIENT_ATINGI_SECRET: ENC[AES256_GCM,data:DlY0gi1K4PZhrwL0bUrbRdPkJj8OVPR/Henggpg=,iv:WIJmW95F6u+zkuQjTnRkqqJ58pYm9XWECKAJm1Q/gkY=,tag:wcB1LUwxwcMEubpy3MbH1A==,type:str]
         CLIENT_GOODWALL_SECRET: ENC[AES256_GCM,data:DzFuS3U4oTKZawUl7jg9ZGk38sD1rX6g32Vnhd8=,iv:id5nH3AklptsJ5aCwviIo23FGUe/+ZE/jOmNy4Cud/I=,tag:YZq8xsXvJfbzazXVuVa7kA==,type:str]
@@ -28,14 +26,14 @@ config-cli:
 sops:
     kms:
         - arn: arn:aws:kms:eu-west-1:210913241065:alias/helm/yoma-dev
-          created_at: "2023-07-27T08:52:40Z"
-          enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
           aws_profile: yoma-sso-dev
-        - arn: arn:aws:kms:eu-west-1:210913241065:alias/helm/yoma-dev
           created_at: "2023-07-27T08:52:40Z"
           enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
+        - arn: arn:aws:kms:eu-west-1:210913241065:alias/helm/yoma-dev
           aws_profile: ""
-    lastmodified: "2025-08-08T08:04:12Z"
-    mac: ENC[AES256_GCM,data:I0PcGIqLwDB87HRtLpUwKBt/rnFd7U4VAQxoD3X6hb3YeX0+Ml9BP75SSjWml/tGzmDlMhEblRElSf/dr8GYWdO+dm9wCsSYJhGiG9V9R9iSbvBTvpzmKRSgDwJBuhg+Xuh1Cxkji6IqyCWlHmIG0sCM/9DAd+IXQANQzADOCS0=,iv:WM1Lu5jkFL0LNpZDVru2sjE7rOOXmiALQCC3rMFCVH0=,tag:CXO/u3DwFpRgHvKDewwNzA==,type:str]
+          created_at: "2023-07-27T08:52:40Z"
+          enc: AQICAHiIBZY/vSCV0N0rJ1zU5SgMLl7KVz/655pZ90kE4uwaNwGu0Cyjy78CVZ6byeSLagJ4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLU2BxuaJtoizWiILAgEQgDs1N8VYfVybiLd4AAvXJfvaOxgr91cT8HlJYoq4t5zG4iMllxEoQkG1V+uU+BViTpIMYrgX4YU9AQ2Pmw==
+    lastmodified: "2026-07-13T10:08:15Z"
+    mac: ENC[AES256_GCM,data:/v7TFQdZOf/2J3bdaZG1jeIrR/W5ZNANN7Fpk4DG5t+Xg2LyBwYep5D8wLUgi4pJVI7n5Jvy4TFzcVG+RjGVmn9BseBnCtdBDxqcyyEGYqwrJOMTMySuKqPhDG+VgL0wxXNOzNdFYhDEMp+ZJYNq7+8Ph6gBr0H7YASsDoohSig=,iv:HP/xSTOz9FX/tf+f3qOhdoIn9OjHt9EVyblDe1RKSuU=,tag:s5NJJEJHM/YA1RW9RPidnQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.10.2
+    version: 3.13.2

--- a/helm/keycloak/conf/local/values.yaml
+++ b/helm/keycloak/conf/local/values.yaml
@@ -135,7 +135,7 @@ config-cli:
   env:
     KEYCLOAK_URL: https://dev.yoma.world/auth
     IMPORT_FILES_LOCATIONS: "/init/*.yaml"
-    # KEYCLOAK_USER: xxx
+    KEYCLOAK_USER: null
     # REALM_YOMA_ADMIN_CLI_SECRET: xxx
     # SMTP_PASSWORD: SG.xxx
     CLIENT_YOMA_API_URL: https://api.dev.yoma.world

--- a/helm/keycloak/conf/prod/secrets.yaml
+++ b/helm/keycloak/conf/prod/secrets.yaml
@@ -22,8 +22,6 @@ config-cli:
         KEYCLOAK_USER: ENC[AES256_GCM,data:k/b9R1DS3lw=,iv:n4OGjLPXpPoyrxCtCz+BPmwwy+fDcD6aG1J1whUzuXw=,tag:Pd+vak3/ZukMe3fcRqHFpg==,type:str]
         SMTP_PASSWORD: ENC[AES256_GCM,data:LwCR9PF2z73J1zlZFlFa8ixC0kUNXaUZknnD8HkAlJvh9Cdf2d+VpgVpBVrZFNduhXpP0KdhCLVKLuJCRaVjxfBHpXQR,iv:CMpgocrcM6xEBdQYOLBrCk5IrbVqXYEvV1C69nY44do=,tag:qvoX9ySxBsp6vUMkzDeVHA==,type:str]
         SA_YOMA_API_PASSWORD: ENC[AES256_GCM,data:MPLCY1E3Swj039pGRR3rVk+kd/yTu8wpMoE/am23nTWGkrO1ESLQOhYSjvhQpR75mBGgAjTdUydLGLIXDN3l2A==,iv:c0tlFfzlwfOJbEU7jkdMZlAv73zi4HmPxwRl25Od7Y0=,tag:SJVUKxl48OhTlDfi9DBb5Q==,type:str]
-        CLIENT_GOODWALL_URL: ENC[AES256_GCM,data:kRsz3mgknW0zzsnZ59eTZYvfmmYXWwo=,iv:QeP1oAHahIeMXqlC5LdD/iLaPXLsbwaWSc9FS1phmzk=,tag:kzPMSf7CzMDQCko8psBMuw==,type:str]
-        CLIENT_GOODWALL_URL_REDIRECT: ENC[AES256_GCM,data:R/pdSyxVNXc9RyWtjoLZpXV6TR/0XYExBQ1I,iv:rWePtIjV2kVk5mR5tkEzotV0glvpOa5Nbdb+fxqnyY4=,tag:QOAz2ABW0d2C58bxnFpcNA==,type:str]
         CLIENT_YOMA_API_SECRET: ENC[AES256_GCM,data:/13ejRP70GT8dhcdpU3NV3FUMz5nKpQr2W30P3zJuTqaiOUF6UW9gODdJ6JLaX7lEWv3ZqboeKucc3/jwUBYZA==,iv:LvsxCVvjI11AsoqMychwZK+7/Dxm49CzHmiJod+a3/U=,tag:MEO/qO2uK5ooHzWRQOktQg==,type:str]
         CLIENT_ATINGI_SECRET: ENC[AES256_GCM,data:vE6SmopFwiyZLum5ieuggToFL42QNKFpCUDm1TWRGdCY6tp9o+bosUl7NXgvyZQZaAkDnARnK5p88yVopHxd0A==,iv:bv4PD4UnUwWk0IKfbuwX9v8ckfYHFDR09KplS0T4xwg=,tag:1paHr+pvPGSRAZe5kT4gyw==,type:str]
         CLIENT_GOODWALL_SECRET: ENC[AES256_GCM,data:C73yEEKzkVGmVcolcqqmmERQBm1z8HImt4/s3DsIRuYatvkhgSR3zwiLsvB583UbziyBPBdzT9BZ5WPrAVQfEQ==,iv:bNwjc70HtWSh7Dw7Fw7MkD0H/YfFeq3LqBejEiakKXc=,tag:HoZym31S/7EY8JGygHGN4w==,type:str]
@@ -38,14 +36,14 @@ config-cli:
 sops:
     kms:
         - arn: arn:aws:kms:eu-west-1:645438834644:alias/helm/yoma-prod
-          created_at: "2024-03-27T13:21:02Z"
-          enc: AQICAHgtFXPbBtEta5PfOXifxiVcy1EnqZH2ATrV2rFy7z90wgEVlL7BoqTZbw17bbd8LtDXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbBvTjVUSQAlicXR9AgEQgDuuwIVxpxb/4XiePVnQArTyqvTYyGzkx6BZEYl8Ekp2bq5DOQ7tAzJsdpRmdc1IsRizEIR/Po3jEJ22DA==
           aws_profile: yoma-sso-prod
-        - arn: arn:aws:kms:eu-west-1:645438834644:alias/helm/yoma-prod
           created_at: "2024-03-27T13:21:02Z"
           enc: AQICAHgtFXPbBtEta5PfOXifxiVcy1EnqZH2ATrV2rFy7z90wgEVlL7BoqTZbw17bbd8LtDXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbBvTjVUSQAlicXR9AgEQgDuuwIVxpxb/4XiePVnQArTyqvTYyGzkx6BZEYl8Ekp2bq5DOQ7tAzJsdpRmdc1IsRizEIR/Po3jEJ22DA==
+        - arn: arn:aws:kms:eu-west-1:645438834644:alias/helm/yoma-prod
           aws_profile: ""
-    lastmodified: "2026-03-31T13:13:14Z"
-    mac: ENC[AES256_GCM,data:LTg6AxmdKLEZSJRWdiAcH5Rx31/G925Tsroij9Iui2aSnfl9wexbGyXkpPrJU9/pZENW4+e8fuMswzP7KICObpqsJ8BQ4YTy1E1h2WtBzYU2IsW4TjbfJP2BCq5mqyGQslOR8UJjCzDn3dTNTWEv+J+54jLmC3/XhZNXZae6oMg=,iv:kPzDqoKLZvkrzulff+vmF+qstrERhDyyYSarf6dqSVo=,tag:hZ8AFbCAr23khbKkgpE3Fw==,type:str]
+          created_at: "2024-03-27T13:21:02Z"
+          enc: AQICAHgtFXPbBtEta5PfOXifxiVcy1EnqZH2ATrV2rFy7z90wgEVlL7BoqTZbw17bbd8LtDXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbBvTjVUSQAlicXR9AgEQgDuuwIVxpxb/4XiePVnQArTyqvTYyGzkx6BZEYl8Ekp2bq5DOQ7tAzJsdpRmdc1IsRizEIR/Po3jEJ22DA==
+    lastmodified: "2026-07-13T10:08:35Z"
+    mac: ENC[AES256_GCM,data:AegOxqT3KBxS8Bx08TKH6o4UFkL/UWw1tKyZuXFFoi/bX6rYBWE47x6KWV107pHBxM3jYBF61X0VrP+DqX2rX1/fTf2AyI/zIjoAI3ty6/82G5gpHW+o8YwRKu5lPqfIoeaTEkbewOs907OQaKDM4tnRnJE2W9D0qHqH8Syc6ug=,iv:4VpP4TKhbfTVf4M9RBjE3H4IKCVl0Q1M0EPlwdp3tuA=,tag:mL8AuR1z5fsc1fcjNGv/0g==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.2

--- a/helm/keycloak/conf/prod/values.yaml
+++ b/helm/keycloak/conf/prod/values.yaml
@@ -89,7 +89,7 @@ config-cli:
   env:
     KEYCLOAK_URL: https://yoma.world/auth
     IMPORT_FILES_LOCATIONS: "/init/*.yaml"
-    # KEYCLOAK_USER: xxx
+    KEYCLOAK_USER: null
     # REALM_YOMA_ADMIN_CLI_SECRET: xxx
     # SMTP_PASSWORD: SG.xxx
     CLIENT_YOMA_API_URL: https://api.yoma.world

--- a/helm/keycloak/conf/stage/secrets.yaml
+++ b/helm/keycloak/conf/stage/secrets.yaml
@@ -18,8 +18,6 @@ config-cli:
         KEYCLOAK_USER: ENC[AES256_GCM,data:eXMN0g6tu3I=,iv:+VFQ4+ug/ux/QKq8GQ4MgPMf/3sqlpgZPAOw3F6qZjg=,tag:AExr/1YRiWwaTRIFZzzdAA==,type:str]
         SMTP_PASSWORD: ENC[AES256_GCM,data:/4aKiGKNlVZNs38ZpEB/tCDMxhnMpE8nRmSu7fzk4JGPZOTGcXBASdDSBYsgRv/a7eYvE3dFg0sGE0PjYN1d0+NTvkTy,iv:7tBBCsMkw8ybCKcHx6nISPL7TafLwo42/q1F+8Az+ws=,tag:R8anpnInNpe2kBG77xj34A==,type:str]
         SA_YOMA_API_PASSWORD: ENC[AES256_GCM,data:1A+kyLR1G3u6G0f0j1K6qpqSdnit2ZrD3BIH2hWAJlY=,iv:EBypn672PuvYqp2yIyu1MgIHtKAQ2z3wbWhZRpPvY40=,tag:mM0B3RVq+PSjWEmsLf/TbA==,type:str]
-        CLIENT_GOODWALL_URL: ENC[AES256_GCM,data:jPUKqYffpsatkfI16sZ77gvGKMpgYw==,iv:zb5jWcm27t8GG2Fp+UivFG7WrEWk9Zkfi9gUYm2JRvg=,tag:J1ikxlsSzxxTjtIDdLeCMA==,type:str]
-        CLIENT_GOODWALL_URL_REDIRECT: ENC[AES256_GCM,data:WoWDWHyNmH9uiM0tyBwFz0DUgadxFlfV12Vk,iv:vImKc8BOMkJEwtMfIxlkxYRpQ43Ie+P1Y9nklCTBZFc=,tag:jIxp6Efh11E0GX7TuJVUyw==,type:str]
         CLIENT_YOMA_API_SECRET: ENC[AES256_GCM,data:fEhDXEDeu2Fs1eqQ7HRNf8lIq6O9OQVA9pwe2sqBKcs=,iv:TbONMYnWzlmbiWjD0TY37caLLIuV+xl/59yMnvgzCOs=,tag:A72JfA/55Ow8bN4IR0gGEA==,type:str]
         CLIENT_ATINGI_SECRET: ENC[AES256_GCM,data:m+fzZill4lqXRQeX3goQKyshdGyCoKNix2TMcsR8ri4=,iv:sVRhQBH904YUFv2GkTNPdxDV86F7pS1YMtzl2T6jC/U=,tag:Pg4LEIZP9JEIKa91e7EbJg==,type:str]
         CLIENT_GOODWALL_SECRET: ENC[AES256_GCM,data:hVpX9E7FsTrID/DVNExopvwR8QSidMVaoUjfSWqDa1w=,iv:7KA2c4jHPRjwkULWJy20SRQJcV6Cj9kDE1Uaf7soyNY=,tag:pa/mX7sAxO1Dx/9MXuu9Xg==,type:str]
@@ -34,14 +32,14 @@ config-cli:
 sops:
     kms:
         - arn: arn:aws:kms:eu-west-1:645438834644:alias/helm/yoma-stage
-          created_at: "2023-07-27T08:58:07Z"
-          enc: AQICAHjZSYvoHo/SZBZoYZnlQgvngcfu02FT/ws+tb1JKL5gAAFqKAa4zEvYHl5zfGT6jdxDAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM5HHYcPV1nEFQcysOAgEQgDuDrtnoa3gA+tLK78KUxsZmjGhlIvziU8VwexUk4y7psFPy968rLeefc4IEZsCSip3AY8xXVkGghMMGPA==
           aws_profile: yoma-sso-prod
-        - arn: arn:aws:kms:eu-west-1:645438834644:alias/helm/yoma-stage
           created_at: "2023-07-27T08:58:07Z"
           enc: AQICAHjZSYvoHo/SZBZoYZnlQgvngcfu02FT/ws+tb1JKL5gAAFqKAa4zEvYHl5zfGT6jdxDAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM5HHYcPV1nEFQcysOAgEQgDuDrtnoa3gA+tLK78KUxsZmjGhlIvziU8VwexUk4y7psFPy968rLeefc4IEZsCSip3AY8xXVkGghMMGPA==
+        - arn: arn:aws:kms:eu-west-1:645438834644:alias/helm/yoma-stage
           aws_profile: ""
-    lastmodified: "2026-03-31T13:13:02Z"
-    mac: ENC[AES256_GCM,data:lAZeFjhCePJ1wRTtlAkFRHSia/tNAjbH0mt4eJN9+g4vjPIRomZKuj2kbcPaRsc1eUnMy/s7CXwgkTKFcWVaNfhvakKZeRZ6ZE0tCGpbO0cyw6Apfj3rZbI6/1naRwknSToVU9GJQetEY1JqXDCJvH1LB/3/l7K/jHwaNcW7SRI=,iv:jU5Rj4YiLSDRIwzilyg29Hs1gVf4wb752JyNIxWdn/U=,tag:QLeWpK5LJRzKA+9M3d2oBA==,type:str]
+          created_at: "2023-07-27T08:58:07Z"
+          enc: AQICAHjZSYvoHo/SZBZoYZnlQgvngcfu02FT/ws+tb1JKL5gAAFqKAa4zEvYHl5zfGT6jdxDAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM5HHYcPV1nEFQcysOAgEQgDuDrtnoa3gA+tLK78KUxsZmjGhlIvziU8VwexUk4y7psFPy968rLeefc4IEZsCSip3AY8xXVkGghMMGPA==
+    lastmodified: "2026-07-13T10:08:26Z"
+    mac: ENC[AES256_GCM,data:G1Bgu05jOcXWSNhCNGG1apCYOJYa+zuu1C0wcz9UHrlQG9boykV8qsJz28SxJfft+aJdNV3AFbNNaCImT6JVRnJHPml0lmKfgmugxGbEvS0FGQvxPpTp5T3AXusnA8HygHxdaU6dQVkLsB2d2cxXPK6I/clhEp1XM4uj/56mruk=,iv:7UbKzDoq/ZEbsoegpdpe26vre+1Aqj4M5s/jIrmpnBk=,tag:sSGXFpAvQWskghF1V2iAeg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.2

--- a/helm/keycloak/conf/stage/values.yaml
+++ b/helm/keycloak/conf/stage/values.yaml
@@ -85,7 +85,7 @@ config-cli:
   env:
     KEYCLOAK_URL: https://stage.yoma.world/auth
     IMPORT_FILES_LOCATIONS: "/init/*.yaml"
-    # KEYCLOAK_USER: xxx
+    KEYCLOAK_USER: null
     # REALM_YOMA_ADMIN_CLI_SECRET: xxx
     # SMTP_PASSWORD: SG.xxx
     CLIENT_YOMA_API_URL: https://v3api.stage.yoma.world

--- a/helm/keycloak/templates/post-install.yaml
+++ b/helm/keycloak/templates/post-install.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       name: {{ include "keycloak.fullname" . }}
       labels:
-        {{- include "keycloak.labels" . | nindent 4 }}
+        {{- include "keycloak.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.postInstallHook.initContainers }}


### PR DESCRIPTION
Unblocks the Keycloak deploy, which fails under Helm 4.2.0's typed-patch / server-side apply because two manifests contain latent errors a prior apply path tolerated. Two independent fixes, both surfaced in the same deploy.

## 1. Duplicate config-cli env keys

The `keycloak-config-cli` post-install Job failed with duplicate `env` keys (`CLIENT_GOODWALL_URL`, `CLIENT_GOODWALL_URL_REDIRECT`, `KEYCLOAK_USER`). The `config-cli` chart renders `.Values.env` and `.Values.secrets` as two independent env lists with no de-duplication, so keys defined in both appeared twice.

Each key now has a single source across dev/stage/prod/local:

- `KEYCLOAK_USER` -> `null` in `config-cli.env` to drop the chart default; resolves solely from the encrypted `secrets`.
- `CLIENT_GOODWALL_URL` / `CLIENT_GOODWALL_URL_REDIRECT` -> kept in `config-cli.env` (non-secret config), removed from `secrets`.

## 2. post-install Job pod-template label indent

The next hook then failed with:

```
.spec.template.app.kubernetes.io/name: field not declared in schema
```

In `helm/keycloak/templates/post-install.yaml`, the pod-template `labels:` block used `nindent 4`, placing labels at the `spec.template` level instead of nesting them under `spec.template.metadata.labels`. Changed to `nindent 8`. The top-level `metadata.labels` is unaffected (correctly `nindent 4`).

## Verification

- config-cli duplicate error confirmed resolved by the deploy run that then progressed to the post-install hook.
- Duplicate keys confirmed removed from all four `secrets.yaml` via key-name grep (no decryption).
- Best confirmed end-to-end by the next deploy run; the post-install rendered Job should show `.spec.template.metadata.labels` and no `.spec.template.app.kubernetes.io/name`.

## Notes

- Secret edits (removals + re-encrypt) were made by the repo owner; this branch stages them alongside the `values.yaml` and template changes.
- `KEYCLOAK_USER: null` relies on Helm null-key-removal during value coalescing.